### PR TITLE
Enable using speech commands to report-to-TOC

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/ReportAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/ReportAction.uc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// RestrainAndReportAction.uc - StackUpAction class
+// ReportAction.uc - StackUpAction class
 // The Action that causes the Officers to report something to TOC
 
 class ReportAction extends SwatCharacterAction;

--- a/Source/Game/SwatGame/Classes/PlayerInteraction/SpeechCommandInterface.uc
+++ b/Source/Game/SwatGame/Classes/PlayerInteraction/SpeechCommandInterface.uc
@@ -143,10 +143,11 @@ simulated function IssueTOCOrder()
 	local SwatAI TargetAI;
 	local array<IInterested_GameEvent_ReportableReportedToTOC> Interested;
 	local Procedure SwatProcedure;
-	local IInterested_GameEvent_ReportableReportedToTOC Reportable;
 	local int i;
 	local name EffectEventName;
 	local bool IsReported;
+	local SwatAI AIListener;
+	local SwatPlayer PlayerListener;
 
 	PlayerController = SwatGamePlayerController(Level.GetLocalPlayerController());
 	if (PlayerController == None) return;
@@ -166,19 +167,16 @@ simulated function IssueTOCOrder()
 		} else {
 			//get the array of all listeners that have been registered to the TOC event
 			Interested = SwatGameInfo(Level.Game).GameEvents.ReportableReportedToTOC.Interested;
-			//loop through the listeners and find the Procedure that handles TOC reports
+			//loop through the listeners and call the ones that don't trigger sound effects
 			for (i=0; i<Commands.Length - 1; ++i)
 			{
-				//if we find a relevant procedure, report the target to TOC
-				SwatProcedure = Procedure(Interested[i]);
-				if (SwatProcedure != None) //filter by procedures so we don't trigger sound effects
+				//listeners on SwatAI and on the Player will trigger sound effects, so we don't trigger them
+				AIListener = SwatAI(Interested[i]);
+				PlayerListener = SwatPlayer(Interested[i]);
+				if (AIListener == None && PlayerListener == None)
 				{
-					Reportable = IInterested_GameEvent_ReportableReportedToTOC(SwatProcedure);
-					if (Reportable != None) //this is a reportable procedure
-					{
-						Reportable.OnReportableReportedToTOC(TargetAI, Player);
-						IsReported = true;
-					}
+					Interested[i].OnReportableReportedToTOC(TargetAI, Player);
+					IsReported = true;
 				}
 			}
 			if (IsReported) {

--- a/Source/Game/SwatGame/Classes/PlayerInteraction/SpeechCommandInterface.uc
+++ b/Source/Game/SwatGame/Classes/PlayerInteraction/SpeechCommandInterface.uc
@@ -148,7 +148,7 @@ simulated function IssueTOCOrder()
 
 	PlayerController = SwatGamePlayerController(Level.GetLocalPlayerController());
 	if (PlayerController == None) return;
-	Player.GetSwatPlayer();
+	Player = PlayerController.GetSwatPlayer();
 	if (Player == None) return;
 	
 	Target = GetPendingTOCReportTargetActor();
@@ -176,9 +176,9 @@ simulated function IssueTOCOrder()
 					TargetAI.PostUsed(); //mark the target as reported
 					//try to play the response-from-toc sound effect
 					EffectEventName = TargetAI.GetEffectEventForReportResponseFromTOC();
-					if (EffectEventName != None) 
+					if (EffectEventName != '') 
 					{
-						Player.TriggerEffectEvent(EffectEventName, Actor(TargetAI), , , , , , , 'TOC');
+						Player.TriggerEffectEvent(EffectEventName, TargetAI, , , , , , , 'TOC');
 					}
 				}
 			}

--- a/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
+++ b/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
@@ -5577,6 +5577,22 @@ simulated function OnOneMinWarning()
     }
 }
 
+//Used by SpeechCommand interface
+simulated function SwatPlayer GetSwatPlayer()
+{
+	local SwatPlayer Player;
+
+	if( pawn != None )
+    {
+        Player = SwatPlayer(Pawn);
+    }
+    if( Player == None && ViewTarget != None )
+    {
+        Player = SwatPlayer(ViewTarget);
+    }
+	
+    return Player;
+}
 
 simulated function bool IsLocationFrozen()
 {

--- a/System/SpeechCommandGrammar.xml
+++ b/System/SpeechCommandGrammar.xml
@@ -31,7 +31,9 @@
     <RULE NAME="Command" TOPLEVEL="ACTIVE">
         <LIST PROPNAME="Command">
             <PHRASE VALSTR="Command_StackUpAndTryDoor">Stack up ...</PHRASE>
-            <PHRASE VALSTR="Command_StackUpAndTryDoor">... the lock ...</PHRASE>
+            <PHRASE VALSTR="Command_StackUpAndTryDoor">Try the lock.</PHRASE>
+		   <PHRASE VALSTR="Command_StackUpAndTryDoor">Try the door.</PHRASE>
+		   <PHRASE VALSTR="Command_StackUpAndTryDoor">Check the door.</PHRASE>
             <PHRASE VALSTR="Command_PickLock">Unlock ...</PHRASE>
             <PHRASE VALSTR="Command_PickLock">Pick ...</PHRASE>
             <PHRASE VALSTR="Command_PickLock">Take care ... lock</PHRASE>
@@ -242,6 +244,8 @@
 			<PHRASE VALSTR="Compliance">... SWAT ...</PHRASE>
 			<PHRASE VALSTR="Compliance">... search warrant ...</PHRASE>
 			<PHRASE VALSTR="Compliance">... Drop ?your ?the weapon ...</PHRASE>
+			<PHRASE VALSTR="Compliance">... see your hands ...</PHRASE>
+			<PHRASE VALSTR="Compliance">Show ?me ?us your hands.</PHRASE>
 		</LIST>
     </RULE>
 


### PR DESCRIPTION
The SpeechCommandInterface had an unfinished code path for reporting NPCs to TOC. These commits finish the feature, allowing the player to report restrained, downed, or killed NPCs to TOC using voice commands. Also included are a few new synonyms for existing voice commands.

Notes:
- The player can only report characters that have not already been reported
- The speech commands for TOC reports do not trigger other types of interactions if you are looking at something other than a reportable character
- Sound effects of the player's character making the report do not play (unless the target is a special objective like Detective Walsh in Casino), but the sound effect of the response from TOC _does_ play
- I have not tested this for co-op; it may need tweaks