### PR TITLE
Improved compliance behavior for suspects

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/ComplianceAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/ComplianceAction.uc
@@ -10,7 +10,7 @@ class ComplianceAction extends LookAtOfficersActionBase
 
 import enum EUpperBodyAnimBehavior from ISwatAI;
 import enum EUpperBodyAnimBehaviorClientId from UpperBodyAnimBehaviorClients;
-
+import enum EnemySkill from ISwatEnemy;
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -138,21 +138,36 @@ function name GetPreComplyAnimation()
 latent final function PreComply()
 {
 	local int ComplyAnimChannel;
-
+	local float AnimationRate;
+	
 	// play the arms up animation
-	ComplyAnimChannel = m_Pawn.AnimPlaySpecial(GetPreComplyAnimation(), 0.1);
+	AnimationRate = RandRange(1.1, 1.6);
+	ComplyAnimChannel = m_Pawn.AnimPlaySpecial(GetPreComplyAnimation(), 0.1, '', AnimationRate);
     m_Pawn.FinishAnim(ComplyAnimChannel);
 
 	// play the compliance animation
-    ComplyAnimChannel = m_Pawn.AnimPlaySpecial(GetComplianceAnimation());
+	AnimationRate = RandRange(1.0, 1.4);
+    ComplyAnimChannel = m_Pawn.AnimPlaySpecial(GetComplianceAnimation(), 0, '', AnimationRate);
     m_Pawn.FinishAnim(ComplyAnimChannel);
 }
 
 latent final function Comply()
 {
     local ISwatAICharacter SwatAICharacter;
+	local ISwatEnemy Enemy;
 
     mplog( "in ComplianceAction::Comply()." );
+	
+	//give them a chance to drop their weapon BEFORE raising their hands,
+	//like a sane person -K.F.
+	Enemy = ISwatEnemy(m_Pawn);
+	if (Enemy != None) 
+	{
+		if (Enemy.ShouldDropWeaponInstantly())
+		{
+			Enemy.DropActiveWeapon();
+		}
+	}
 
     if (bJustComplied)
 	{
@@ -170,10 +185,10 @@ latent final function Comply()
     }
 
 	// makes sure the weapon is dropped if we are an enemy
-	if (m_Pawn.IsA('SwatEnemy'))
+	if (Enemy != None)
 	{
-		ISwatEnemy(m_Pawn).DropAllWeapons();
-		ISwatEnemy(m_Pawn).DropAllEvidence(false);
+		Enemy.DropAllWeapons();
+		Enemy.DropAllEvidence(false);
 	}
 }
 

--- a/Source/Game/SwatAICommon/Classes/ISwatEnemy.uc
+++ b/Source/Game/SwatAICommon/Classes/ISwatEnemy.uc
@@ -62,10 +62,16 @@ function FiredWeapon GetBackupWeapon();
 
 function PickUpWeaponModel(HandHeldEquipmentModel HHEModel);
 
+// Tell the enemy to drop his active weapon, and give the
+// falling weapon the specified impulse (in weapon-local space). 
+function DropActiveWeapon(optional vector WeaponSpaceDropDirection, optional float DropImpulseMagnitude);
 // Tell the enemy to drop all of his weapons, if it is being shown, and give the
 // falling weapon the specified impulse (in weapon-local space).
 function DropAllWeapons(optional vector WeaponSpaceDropDirection, optional float DropImpulseMagnitude);
 function ThrowWeaponDown();
+
+//Get whether the suspect chooses to drop his/her weapon instantly when complying
+function bool ShouldDropWeaponInstantly();
 
 // Tell the enemy to drop any evidence he is holding
 function DropAllEvidence(bool bIsDestroying);

--- a/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
+++ b/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
@@ -1239,6 +1239,16 @@ simulated function ClientAIDroppedAllWeapons( SwatEnemy theDropper )
     }
 }
 
+simulated function ClientAIDroppedActiveWeapon( SwatEnemy theDropper )
+{
+    mplog( "---SGPC::ClientAIDroppedActiveWeapon(). dropper="$theDropper );
+
+    if ( theDropper != None )
+    {
+        theDropper.DropActiveWeapon();
+    }
+}
+
 simulated function ClientAIDroppedAllEvidence( SwatEnemy theDropper, bool bIsDestroying )
 {
     mplog( "---SGPC::ClientAIDroppedAllEvidence(). dropper="$theDropper );

--- a/System/SwatPawn.ini
+++ b/System/SwatPawn.ini
@@ -411,6 +411,13 @@ HighSkillFullBodyHitChance=0.7
 MediumSkillFullBodyHitChance=0.8
 LowSkillFullBodyHitChance=0.9
 
+; chance that we will drop weapons instantly when complying
+;   Unused at the moment; can't seem to compile SwatEnemy with new config vars
+;   For now, reusing the FullBodyHitChance vars as a substitute. -K.F.
+;HighSkillComplyInstantDropChance=0.7
+;MediumSkillComplyInstantDropChance=0.8
+;LowSkillComplyInstantDropChance=0.9
+
 [SwatGame.SwatWildGunner]
 ; Range of time per skill level that an Enemy will fire full auto for
 LowSkillMinTimeToFireFullAuto=3.0


### PR DESCRIPTION
Give suspects a high chance to drop their active weapon immediately when they begin compliance; in other words, to drop their weapon _before_ they raise their hands rather than after. Also increases the speed of the compliance animations in a random range. This behavior seems more realistic and reduces instances of accidentally shooting a suspect who is surrendering because he was raising his weapon as part of the compliance animation.

Since adding config variables to SwatEnemy triggers a runtime error, I used the hacky solution of re-using the values from the FullBodyHitChance variables since they are actually the same values I was going to use anyway.

I opted to give low-skill suspects a greater chance of dropping their weapon instantly; high-skill suspects presumably have more nerve to hang on to their weapon, and we also want to keep the tension of "is he really going to drop it or is he faking?"