### PR TITLE
IRON SIGHTS!!

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/ComplianceAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/ComplianceAction.uc
@@ -29,6 +29,11 @@ var config array<name>	StandingArmsUpAnimations;
 var config array<name>	CrouchingStunnedArmsUpAnimations;
 var config array<name>	StandingStunnedArmsUpAnimations;
 
+var config float 		MinArmsUpAnimationRate;
+var config float		MaxArmsUpAnimationRate;
+var config float		MinKneelAnimationRate;
+var config float		MaxKneelAnimationRate;
+
 var private bool		bJustComplied;
 
 const kPostComplianceGoalPriority = 91;	// lower than being stunned or shot
@@ -141,12 +146,12 @@ latent final function PreComply()
 	local float AnimationRate;
 	
 	// play the arms up animation
-	AnimationRate = RandRange(1.1, 1.6);
+	AnimationRate = RandRange(MinArmsUpAnimationRate, MaxArmsUpAnimationRate);
 	ComplyAnimChannel = m_Pawn.AnimPlaySpecial(GetPreComplyAnimation(), 0.1, '', AnimationRate);
     m_Pawn.FinishAnim(ComplyAnimChannel);
 
 	// play the compliance animation
-	AnimationRate = RandRange(1.0, 1.4);
+	AnimationRate = RandRange(MinKneelAnimationRate, MaxKneelAnimationRate);
     ComplyAnimChannel = m_Pawn.AnimPlaySpecial(GetComplianceAnimation(), 0, '', AnimationRate);
     m_Pawn.FinishAnim(ComplyAnimChannel);
 }

--- a/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
+++ b/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
@@ -1435,6 +1435,30 @@ exec function NextFireMode()
         FiredWeapon(ActiveItem).NextFireMode();
 }
 
+exec function SetWeaponViewOffset(vector offset)
+{
+	local HandheldEquipment ActiveItem;
+	local SwatWeapon ActiveWeapon;
+
+    ActiveItem = Pawn.GetActiveItem();
+	ActiveWeapon = SwatWeapon(ActiveItem);
+	if (ActiveWeapon != None) {
+		ActiveWeapon.DefaultLocationOffset = offset;
+	}
+}
+
+exec function SetWeaponViewRotation(rotator Rotation)
+{
+	local HandheldEquipment ActiveItem;
+	local SwatWeapon ActiveWeapon;
+
+    ActiveItem = Pawn.GetActiveItem();
+	ActiveWeapon = SwatWeapon(ActiveItem);
+	if (ActiveWeapon != None) {
+		ActiveWeapon.DefaultRotationOffset = Rotation;
+	}
+}
+
 exec function SetIronSightOffset(vector offset)
 {
 	local HandheldEquipment ActiveItem;

--- a/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
+++ b/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
@@ -1435,6 +1435,42 @@ exec function NextFireMode()
         FiredWeapon(ActiveItem).NextFireMode();
 }
 
+exec function SetIronSightOffset(vector offset)
+{
+	local HandheldEquipment ActiveItem;
+	local SwatWeapon ActiveWeapon;
+
+    ActiveItem = Pawn.GetActiveItem();
+	ActiveWeapon = SwatWeapon(ActiveItem);
+	if (ActiveWeapon != None) {
+		ActiveWeapon.IronSightLocationOffset = offset;
+	}
+}
+
+exec function SetIronSightRotation(rotator Rotation)
+{
+	local HandheldEquipment ActiveItem;
+	local SwatWeapon ActiveWeapon;
+
+    ActiveItem = Pawn.GetActiveItem();
+	ActiveWeapon = SwatWeapon(ActiveItem);
+	if (ActiveWeapon != None) {
+		ActiveWeapon.IronSightRotationOffset = Rotation;
+	}
+}
+
+exec function SetWeaponViewInertia(float Inertia)
+{
+	local HandheldEquipment ActiveItem;
+	local SwatWeapon ActiveWeapon;
+
+    ActiveItem = Pawn.GetActiveItem();
+	ActiveWeapon = SwatWeapon(ActiveItem);
+	if (ActiveWeapon != None) {
+		ActiveWeapon.ViewInertia = Inertia;
+	}
+}
+
 simulated function SwatDoor GetDoorInWay()
 {
     local SwatDoor DoorActor;

--- a/Source/Game/SwatGame/Classes/SwatPlayer.uc
+++ b/Source/Game/SwatGame/Classes/SwatPlayer.uc
@@ -2034,7 +2034,15 @@ Begin:
 ////////////////////////////////////////////////////////////////////////////////
 
 simulated function Tick(float dTime) {
-  AdjustPlayerMovementSpeed();
+
+    local Hands MyHands;
+
+    AdjustPlayerMovementSpeed();
+    
+    MyHands = GetHands();
+    if ( MyHands != None )
+        MyHands.UpdateHandsForRendering(dTime);
+
 }
 
 

--- a/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
@@ -134,6 +134,7 @@ var config vector PlayerViewOffset;
 var config Rotator IronSightRotationOffset;
 var config Rotator PlayerViewRotation;
 var config float ZoomedAimErrorModifier;
+var config float ViewInertia;
 
 var bool bPenetratesDoors;
 
@@ -275,6 +276,11 @@ simulated function vector GetIronsightsLocationOffset()
 simulated function Rotator GetIronsightsRotationOffset()
 {
     return IronSightRotationOffset;
+}
+
+simulated function float GetViewInertia() 
+{
+	return ViewInertia;
 }
 
 simulated function float GetBaseAimError()

--- a/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
@@ -138,6 +138,10 @@ var config Rotator PlayerViewRotation;
 var config float ZoomedAimErrorModifier;
 var config float ViewInertia;
 
+//a bit of a hack since we can't add vars to Hands.uc - K.F.
+var float IronSightAnimationPosition;	//denotes position of weapon, in linear range where 0 = held at hip and 1 = fully aiming down sight
+var vector ViewLocationLastFrame;
+
 var bool bPenetratesDoors;
 
 simulated function float GetWeight() {
@@ -293,6 +297,28 @@ simulated function Rotator GetIronsightsRotationOffset()
 simulated function float GetViewInertia() 
 {
 	return ViewInertia;
+}
+
+simulated function float GetIronSightAnimationPosition() 
+{
+	return IronSightAnimationPosition;
+}
+
+simulated function SetIronSightAnimationPosition(float value)
+{
+	if (value < 0) value = 0;
+	if (value > 1) value = 1;
+	IronSightAnimationPosition = value;
+}
+
+simulated function vector GetViewLocationLastFrame() 
+{
+	return ViewLocationLastFrame;
+}
+
+simulated function SetViewLocationLastFrame(vector value)
+{
+	ViewLocationLastFrame = value;
 }
 
 simulated function float GetBaseAimError()

--- a/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
@@ -277,52 +277,6 @@ simulated function Rotator GetIronsightsRotationOffset()
     return IronSightRotationOffset;
 }
 
-simulated function vector GetPlayerViewOffset()
-{
-	local vector ViewOffset;
-	local Pawn OwnerPawn;
-	local PlayerController OwnerController;
-
-	ViewOffset = PlayerViewOffset;
-
-	OwnerPawn = Pawn(Owner);
-
-	if (OwnerPawn!= None)
-	{
-		OwnerController = PlayerController(OwnerPawn.Controller);
-
-		if (OwnerController != None && OwnerController.WantsZoom)
-		{
-			return IronSightLocationOffset;
-		}
-	}
-
-	return ViewOffset;
-}
-
-simulated function rotator GetPlayerViewRotation()
-{
-	local Rotator ViewRotation;
-	local Pawn OwnerPawn;
-	local PlayerController OwnerController;
-
-	ViewRotation = PlayerViewRotation;
-
-	OwnerPawn = Pawn(Owner);
-
-	if (OwnerPawn!= None)
-	{
-		OwnerController = PlayerController(OwnerPawn.Controller);
-
-		if (OwnerController != None && OwnerController.WantsZoom)
-		{
-			return IronSightRotationOffset;
-		}
-	}
-
-	return ViewRotation;
-}
-
 simulated function float GetBaseAimError()
 {
 	local float BaseAimError;

--- a/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
@@ -129,6 +129,8 @@ var(Categorization) public config WeaponEquipType AllowedSlots               "Wh
 var() public config float Weight;
 var() public config float Bulk;
 
+var config vector DefaultLocationOffset;
+var config Rotator DefaultRotationOffset;
 var config vector IronSightLocationOffset;
 var config vector PlayerViewOffset;
 var config Rotator IronSightRotationOffset;
@@ -266,6 +268,16 @@ function bool ValidIdleCategory(EIdleWeaponStatus DesiredStatus)
     }
   }
   return false; // This isn't a valid idle category for this weapon
+}
+
+simulated function vector GetDefaultLocationOffset()
+{
+    return DefaultLocationOffset;
+}
+
+simulated function Rotator GetDefaultRotationOffset()
+{
+    return DefaultRotationOffset;
 }
 
 simulated function vector GetIronsightsLocationOffset()

--- a/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
@@ -1235,14 +1235,14 @@ simulated function vector GetIronsightsLocationOffset()
 {
 	local vector IronsightsLocation;
 
-    return IronsightsLocation;
+	return IronsightsLocation;
 }
 
 simulated function Rotator GetIronsightsRotationOffset()
 {
 	local Rotator IronsightsRotation;
 
-    return IronsightsRotation;
+	return IronsightsRotation;
 }
 
 simulated function float GetViewInertia() 
@@ -1251,6 +1251,22 @@ simulated function float GetViewInertia()
 	
 	return Inertia;
 }
+
+simulated function float GetIronSightAnimationPosition()
+{
+	local float IronSightAnimationPosition;
+	
+	return IronSightAnimationPosition;
+}
+simulated function SetIronSightAnimationPosition(float value) { }
+
+simulated function vector GetViewLocationLastFrame()
+{
+	local vector ViewLocationLastFrame;
+
+	return ViewLocationLastFrame;
+}
+simulated function SetViewLocationLastFrame(vector value) { }
 
 event Destroyed()
 {

--- a/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
@@ -1224,13 +1224,6 @@ simulated function vector GetIronsightsLocationOffset()
     return IronsightsLocation;
 }
 
-simulated function vector GetPlayerViewOffset()
-{
-	local vector PlayerViewOffset;
-
-    return PlayerViewOffset;
-}
-
 simulated function Rotator GetIronsightsRotationOffset()
 {
 	local Rotator IronsightsRotation;
@@ -1238,11 +1231,11 @@ simulated function Rotator GetIronsightsRotationOffset()
     return IronsightsRotation;
 }
 
-simulated function rotator GetPlayerViewRotation()
+simulated function float GetViewInertia() 
 {
-	local rotator PlayerViewRotation;
-
-    return PlayerViewRotation;
+	local float Inertia;
+	
+	return Inertia;
 }
 
 event Destroyed()

--- a/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
@@ -1217,6 +1217,20 @@ static function class<Actor> GetRenderableActorClass()
     return default.ThirdPersonModelClass;
 }
 
+simulated function vector GetDefaultLocationOffset()
+{
+	local vector DefaultLocationOffset;
+	
+	return DefaultLocationOffset;
+}
+
+simulated function Rotator GetDefaultRotationOffset()
+{
+	local Rotator DefaultRotationOffset;
+	
+	return DefaultRotationOffset;
+}
+
 simulated function vector GetIronsightsLocationOffset()
 {
 	local vector IronsightsLocation;

--- a/Source/Unreal/Engine/Classes/Equipment/Hands.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Hands.uc
@@ -107,8 +107,12 @@ simulated function UpdateHandsForRendering()
 	
 		//this converts local offset to world coordinates
 		Offset = EquippedItem.GetIronsightsLocationOffset() >> NewRotation;
-		TargetLocation = TargetLocation + Offset;
+	} else {
+		//HACK: offset when the player isn't using iron sights, to fix the ******* P90 -K.F.
+		NewRotation += EquippedItem.GetDefaultRotationOffset();
+		Offset = EquippedItem.GetDefaultLocationOffset() >> NewRotation;
 	}
+	TargetLocation = TargetLocation + Offset;
 	
 	//interpolate towards our target location. inertia controls how quickly the weapon 
 	//visually responds to our movements

--- a/Source/Unreal/Engine/Classes/Equipment/Hands.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Hands.uc
@@ -192,7 +192,9 @@ simulated function IdleHoldingEquipment()
     local HandheldEquipmentModel Model;
     local HandheldEquipment theActiveItem;
     local float SavedTweenTime;
-
+    local Pawn OwnerPawn;
+    local PlayerController OwnerController;
+    
     //only use a tween time once each time it is set
     SavedTweenTime = NextIdleTweenTime;
     SetNextIdleTweenTime(0.0);
@@ -200,6 +202,18 @@ simulated function IdleHoldingEquipment()
     theActiveItem = GetActiveItem();
     if ( theActiveItem == None )
         return;
+
+	//if the player is zooming, don't play the idle animation unless it changes our lowReady state
+	OwnerPawn = Pawn(Owner);
+	//if SavedTweenTime is 0, this is a generic idle animation, not a lowReady transitioning
+	if (SavedTweenTime == 0 && OwnerPawn != None)
+	{
+		OwnerController = PlayerController(OwnerPawn.Controller);
+		if (OwnerController != None && OwnerController.WantsZoom)
+		{
+			return;
+		}
+	}
 
     Model = theActiveItem.GetFirstPersonModel();
     

--- a/Source/Unreal/Engine/Classes/Equipment/Hands.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Hands.uc
@@ -64,22 +64,22 @@ simulated function onMessage(Message m)
 simulated function UpdateHandsForRendering()
 {
     local Pawn OwnerPawn;
-	local PlayerController OwnerController;
+    local PlayerController OwnerController;
     local vector TargetLocation;
-	local vector NewLocation;
+    local vector NewLocation;
     local rotator NewRotation;
     local HandheldEquipmentModel EquippedFirstPersonModel;
     local HandheldEquipment EquippedItem;
-	local vector Offset;
-	local float ViewInertia;
+    local vector Offset;
+    local float ViewInertia;
     
     OwnerPawn = Pawn(Owner);
     if (OwnerPawn == None)
     {
         AssertWithDescription(false,"[tcohen] Hands.UpdateHandsForRendering() was called, but its Owner wasn't a Pawn.");
     }
-	
-	 // Implement "showhands" command in SwatCheatManager.
+    
+    // Implement "showhands" command in SwatCheatManager.
     // Native code sets bHidden on hands/gun every tick, so we hide
     // the hands in native code. But we need to hide/show the first person
     // model each tick here.
@@ -89,7 +89,7 @@ simulated function UpdateHandsForRendering()
         EquippedFirstPersonModel = EquippedItem.FirstPersonModel;
         if (EquippedFirstPersonModel != None)
         {
-            EquippedFirstPersonModel.bOwnerNoSee = !OwnerPawn.bRenderHands;        
+            EquippedFirstPersonModel.bOwnerNoSee = !OwnerPawn.bRenderHands;
         }
     }
 	
@@ -103,6 +103,8 @@ simulated function UpdateHandsForRendering()
 	//if the player is zooming, add the iron sight offset to the new location
 	OwnerController = PlayerController(OwnerPawn.Controller);
 	if (OwnerController != None && OwnerController.WantsZoom) {
+		NewRotation += EquippedItem.GetIronsightsRotationOffset();
+	
 		//this converts local offset to world coordinates
 		Offset = EquippedItem.GetIronsightsLocationOffset() >> NewRotation;
 		TargetLocation = TargetLocation + Offset;
@@ -113,7 +115,7 @@ simulated function UpdateHandsForRendering()
 	ViewInertia = EquippedItem.GetViewInertia();
 	NewLocation = (Location * ViewInertia + TargetLocation * (1 - ViewInertia));
 
-    bOwnerNoSee = !OwnerPawn.bRenderHands;
+	bOwnerNoSee = !OwnerPawn.bRenderHands;
 
 	// Special-case exception: even if hands/weapon rendering is disabled,
 	// the hands and weapon should be shown when the optiwand is equipped
@@ -127,7 +129,7 @@ simulated function UpdateHandsForRendering()
 		bOwnerNoSee = false;
 	}
 
-	SetLocation(NewLocation);
+    SetLocation(NewLocation);
     SetRotation(NewRotation);
 }
 

--- a/Source/Unreal/Engine/Classes/Pawn.uc
+++ b/Source/Unreal/Engine/Classes/Pawn.uc
@@ -892,16 +892,8 @@ simulated function vector CalcDrawOffset()
 	if ( Controller == None )
 		return (Hands.PlayerViewOffset >> Rotation) + BaseEyeHeight * vect(0,0,1);
 	
-	EquippedItem = GetActiveItem();
-
-	if (EquippedItem.IsA('FiredWeapon'))
-	{
-		DrawOffset = ((90/FirstPersonFOV * EquippedItem.GetPlayerViewOffset()) >> GetViewRotation() );
-	}
-	else
-	{
-		DrawOffset = ((90/FirstPersonFOV * Hands.PlayerViewOffset) >> GetViewRotation() );
-	}	
+	DrawOffset = ((90/FirstPersonFOV * Hands.PlayerViewOffset) >> GetViewRotation() );
+	
 	if ( !IsLocallyControlled() )
 		DrawOffset.Z += BaseEyeHeight;
 	else
@@ -2922,6 +2914,7 @@ simulated event rotator ViewRotationOffset()
 
 simulated function vector ViewLocationOffset(Rotator CameraRotation)
 {
+	//return vect(sin(CameraRotation.Yaw), cos(CameraRotation.Yaw), 0);
     return vect(0,0,0);
 }
 

--- a/System/AI.ini
+++ b/System/AI.ini
@@ -563,6 +563,11 @@ HighSkillSuccessAfterFiringChance=0.0
 MinInitialDelayTime=0.0
 MaxInitialDelayTime=1.0
 
+MinArmsUpAnimationRate=1.0
+MaxArmsUpAnimationRate=1.5
+MinKneelAnimationRate=1.0
+MaxKneelAnimationRate=1.3
+
 ; ANIMATORS ONLY
 CrouchingComplianceAnimations=cComply
 StandingComplianceAnimations=sComply

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -39,7 +39,7 @@ PlayerViewOffset=(X=-22,Y=7,Z=-12)
 PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
 ;Controls position of weapon when you aren't aiming down sights
 ;X = forward/backwards, Y = Right / Left, Z = Up / Down
-DefaultLocationOffset=(X=0,Y=0,Z=0)
+DefaultLocationOffset=(X=0,Y=0,Z=2)
 DefaultRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ;Controls position of the weapon when you aim down sights
 IronSightLocationOffset=(X=1,Y=-7.40,Z=4.65)
@@ -917,7 +917,7 @@ RecoilMagnitude=180
 
 
 ;***************************
-; H&K MP5SSD
+; H&K MP5SSD6
 ;***************************
 [SwatEquipment.MP5SSDSMG]
 ;; Ammo information
@@ -935,7 +935,7 @@ Bulk=17.42
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.mp5sd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.mp5sd_ThirdPerson'
-IronSightLocationOffset=(X=0,Y=-6.1,Z=5.35)
+IronSightLocationOffset=(X=3,Y=-6,Z=5.1)
 
 ;; GUI
 GUIImage=material'gui_sas.mp5sd_gui'

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -35,6 +35,9 @@ PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
 IronSightLocationOffset=(X=0,Y=-7.5,Z=4.75) 
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ZoomedAimErrorModifier=0.75
+;ViewInertia controls how much the weapon moves when you move, 
+;and how quickly you can align the iron sights
+;Valid range is 0 - 1
 ViewInertia=0.85;
 ComplianceAnimation=Compliance_Handgun
 

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -32,7 +32,6 @@ FirstPersonPreThrowAnimation=PullPin
 [Engine.SwatWeapon]
 PlayerViewOffset=(X=-22,Y=7,Z=-12)
 PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
-;IronSightLocationOffset=(X=-22,Y=7,Z=-12)
 IronSightLocationOffset=(X=0,Y=-7.5,Z=4.75) 
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ZoomedAimErrorModifier=0.75
@@ -176,6 +175,7 @@ Bulk=2.9337
 FirstPersonModelClass=class'SwatEquipmentModels2.ColtM1911_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.ColtM1911_ThirdPerson'
 UnequipAnimationRate=1.5
+IronSightLocationOffset=(X=0,Y=-7.1,Z=6.3)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -244,6 +244,7 @@ Bulk=2.5668
 GUIImage=material'gui_tex.equip_9mmpistol'
 WeaponCategory=WeaponClass_Pistol
 AllowedSlots=WeaponEquip_Either
+IronSightLocationOffset=(X=0,Y=-7.1,Z=6.3)
 
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.NineMMpistol_FirstPerson'
@@ -1243,6 +1244,7 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.UMP45_ThirdPerson'
 AimAnimation=WeaponAnimAim_UMP
 LowReadyAnimation=WeaponAnimLowReady_UMP
 IdleWeaponCategory=IdleWithUMP
+IronSightLocationOffset=(X=3,Y=-5.5,Z=4.25) 
 
 ;; GUI
 GUIImage=material'gui_tex.equip_Ump'
@@ -1325,6 +1327,7 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.M4A1_ThirdPerson'
 AimAnimation=WeaponAnimAim_M4
 LowReadyAnimation=WeaponAnimLowReady_M4
 IdleWeaponCategory=IdleWithMachineGun
+IronSightLocationOffset=(X=0,Y=-6.5,Z=3.65) 
 
 ;; GUI
 GUIImage=material'gui_tex.equip_m4a1'

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -65,7 +65,7 @@ LowReadyAnimation=WeaponAnimLowReady_SubmachineGun
 IdleWeaponCategory=IdleWithSubmachineGun
 ZoomedFOV=60.0
 ZoomTime=0.25
-ViewInertia=0.65;
+ViewInertia=0.35;
 ComplianceAnimation=Compliance_SubmachineGun
 
 [SwatEquipment.Handgun]
@@ -78,7 +78,7 @@ LowReadyAnimation=WeaponAnimLowReady_Handgun
 IdleWeaponCategory=IdleWithHandgun
 ZoomedFOV=60.0
 ZoomTime=0.25
-ViewInertia=0.55;
+ViewInertia=0.25;
 ComplianceAnimation=Compliance_Handgun
 
 [SwatEquipment.MachineGun]
@@ -91,7 +91,7 @@ LowReadyAnimation=WeaponAnimLowReady_Machinegun
 IdleWeaponCategory=IdleWithG36
 ZoomedFOV=45.0
 ZoomTime=0.25
-ViewInertia=0.73;
+ViewInertia=0.45;
 ComplianceAnimation=Compliance_MachineGun
 
 [SwatEquipment.Shotgun]
@@ -102,7 +102,7 @@ LightstickThrowAnimPostfix="SG"
 Choke=1.81
 ZoomedFOV=60.0
 ZoomTime=0.25
-ViewInertia=0.78;
+ViewInertia=0.5;
 ; Handling qualities similar to shotguns (can be overridden)
 AimErrorBreakingPoint=4.0
 LookAimErrorPenaltyFactor=0.000125
@@ -119,7 +119,7 @@ LowReadyAnimation=WeaponAnimLowReady_Paintball
 IdleWeaponCategory=IdleWithPaintballGun
 ZoomedFOV=60.0
 ZoomTime=0.25
-ViewInertia=0.75;
+ViewInertia=0.4;
 ComplianceAnimation=Compliance_CSBallLauncher
 
 [SwatEquipment.BeanbagShotgunBase]
@@ -149,7 +149,7 @@ IdleWeaponCategory=IdleWithG36
 ZoomedFOV=60.0
 ZoomTime=0.25
 ComplianceAnimation=Compliance_Shotgun
-ViewInertia=0.85;
+ViewInertia=0.6;
 
 
 ;********************************

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -792,6 +792,8 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.P90_ThirdPerson'
 AimAnimation=WeaponAnimAim_P90
 LowReadyAnimation=WeaponAnimLowReady_P90
 IdleWeaponCategory=IdleWithP90
+IronSightLocationOffset=(X=6,Y=-7.0,Z=3.4)
+IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=1200)
 
 ;; GUI
 GUIImage=material'gui_tex2.equip_p90'

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -991,6 +991,8 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.mp5k_ThirdPerson'
 AimAnimation=WeaponAnimAim_UMP
 LowReadyAnimation=WeaponAnimLowReady_UMP
 IdleWeaponCategory=IdleWithUMP
+IronSightLocationOffset=(X=0.5,Y=-6.0,Z=5.8) 
+IronSightRotationOffset=(Pitch=-70,Yaw=0,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_sas.mp5k_gui'
@@ -1023,7 +1025,7 @@ LookAimErrorPenaltyFactor=0.000125
 MaxInjuredAimErrorPenalty=1.82
 MaxLookAimErrorPenalty=3.04
 StandToWalkAimErrorPenalty=2.43
-WalkToRunAimErrorPenalty=12.14
+WalkToRunAimErrorPenalty=11.14
 
 ; Aim error modifiers
 CrouchingAimError=0.75
@@ -1065,6 +1067,8 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.mp5ksd_ThirdPerson'
 AimAnimation=WeaponAnimAim_UMP
 LowReadyAnimation=WeaponAnimLowReady_UMP
 IdleWeaponCategory=IdleWithUMP
+IronSightLocationOffset=(X=0.5,Y=-6.0,Z=5.8) 
+IronSightRotationOffset=(Pitch=-70,Yaw=0,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_sas.mp5ksd_gui'
@@ -1088,7 +1092,7 @@ LookAimErrorPenaltyFactor=0.000125
 MaxInjuredAimErrorPenalty=2.69
 MaxLookAimErrorPenalty=4.49
 StandToWalkAimErrorPenalty=3.59
-WalkToRunAimErrorPenalty=17.96
+WalkToRunAimErrorPenalty=16.96
 
 ; Aim error modifiers
 CrouchingAimError=0.83
@@ -2195,6 +2199,8 @@ Bulk=11.952
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.rem870_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.rem870_ThirdPerson'
+IronSightLocationOffset=(X=9.5,Y=-7.0,Z=1.1)
+IronSightRotationOffset=(Pitch=800,Yaw=0,Roll=0)
 
 ;; Flashlight
 HasAttachedFlashlight=true

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -39,7 +39,7 @@ PlayerViewOffset=(X=-22,Y=7,Z=-12)
 PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
 ;Controls position of the weapon when you aim down sights
 ;X = forward/backwards, Y = Right / Left, Z = Up / Down
-IronSightLocationOffset=(X=0,Y=-7.5,Z=4.75) 
+IronSightLocationOffset=(X=1,Y=-7.40,Z=4.65)
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ZoomedAimErrorModifier=0.75
 ;ViewInertia controls how much the weapon moves when you move, 
@@ -185,8 +185,8 @@ Bulk=2.9337
 FirstPersonModelClass=class'SwatEquipmentModels2.ColtM1911_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.ColtM1911_ThirdPerson'
 UnequipAnimationRate=1.5
-IronSightLocationOffset=(X=0,Y=-7.75,Z=2.0)
-IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
+IronSightLocationOffset=(X=3,Y=-7.68,Z=1.8)
+IronSightRotationOffset=(Pitch=800,Yaw=0,Roll=700)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -255,8 +255,8 @@ Bulk=2.5668
 GUIImage=material'gui_tex.equip_9mmpistol'
 WeaponCategory=WeaponClass_Pistol
 AllowedSlots=WeaponEquip_Either
-IronSightLocationOffset=(X=0,Y=-7.9,Z=2.5)
-IronSightRotationOffset=(Pitch=780,Yaw=0,Roll=850)
+IronSightLocationOffset=(X=3,Y=-7.75,Z=2.7)
+IronSightRotationOffset=(Pitch=640,Yaw=0,Roll=700)
 
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.NineMMpistol_FirstPerson'
@@ -327,6 +327,9 @@ AllowedSlots=WeaponEquip_Either
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.PythonRevolver_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.PythonRevolver_ThirdPerson'
+;TODO: not tuned yet
+IronSightLocationOffset=(X=0,Y=-7.65,Z=1.7)
+IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
 
 ;; Flashlight
 HasAttachedFlashlight=false
@@ -390,6 +393,9 @@ AllowedSlots=WeaponEquip_Either
 FirstPersonModelClass=class'SwatEquipmentModels2.DesertEagle_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.DesertEagle_ThirdPerson'
 ReloadAnimationRate=0.80
+;TODO: not tuned yet
+IronSightLocationOffset=(X=0,Y=-7.65,Z=1.7)
+IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
 
 ;; Flashlight
 HasAttachedFlashlight=false
@@ -450,6 +456,9 @@ Bulk=2.758
 FirstPersonModelClass=class'SwatEquipmentModels2.BrowHP_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.BrowHP_ThirdPerson'
 UnequipAnimationRate=1.5
+;TODO: not tuned yet
+IronSightLocationOffset=(X=0,Y=-7.65,Z=1.7)
+IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
 
 ;; Flashlight
 HasAttachedFlashlight=false
@@ -513,6 +522,9 @@ Bulk=4.018
 FirstPersonModelClass=class'SwatEquipmentModels2.BrowHPsd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.BrowHPsd_ThirdPerson'
 UnequipAnimationRate=1.5
+;TODO: not tuned yet
+IronSightLocationOffset=(X=0,Y=-7.65,Z=1.7)
+IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
 
 ;; Flashlight
 HasAttachedFlashlight=false
@@ -993,7 +1005,7 @@ AimAnimation=WeaponAnimAim_UMP
 LowReadyAnimation=WeaponAnimLowReady_UMP
 IdleWeaponCategory=IdleWithUMP
 IronSightLocationOffset=(X=0.5,Y=-6.0,Z=5.8) 
-IronSightRotationOffset=(Pitch=-70,Yaw=0,Roll=0)
+IronSightRotationOffset=(Pitch=-110,Yaw=0,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_sas.mp5k_gui'
@@ -1069,7 +1081,7 @@ AimAnimation=WeaponAnimAim_UMP
 LowReadyAnimation=WeaponAnimLowReady_UMP
 IdleWeaponCategory=IdleWithUMP
 IronSightLocationOffset=(X=0.5,Y=-6.0,Z=5.8) 
-IronSightRotationOffset=(Pitch=-70,Yaw=0,Roll=0)
+IronSightRotationOffset=(Pitch=-110,Yaw=0,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_sas.mp5ksd_gui'
@@ -1132,7 +1144,8 @@ Bulk=17.68
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.MP5_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.MP5_ThirdPerson'
-IronSightLocationOffset=(X=2,Y=-5.8,Z=3.85) 
+IronSightLocationOffset=(X=2,Y=-5.7,Z=4.1) 
+IronSightRotationOffset=(Pitch=-90,Yaw=0,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_tex.equip_mp5'
@@ -1201,7 +1214,8 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SDSMG_JHP",Chance=20)
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.SilencedMP5_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.SilencedMP5_ThirdPerson'
-IronSightLocationOffset=(X=2,Y=-5.8,Z=3.85) 
+IronSightLocationOffset=(X=2,Y=-5.7,Z=4.1) 
+IronSightRotationOffset=(Pitch=-90,Yaw=0,Roll=0)
 
 ;; Weight and Bulk
 Weight=2.78
@@ -1264,7 +1278,7 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.UMP45_ThirdPerson'
 AimAnimation=WeaponAnimAim_UMP
 LowReadyAnimation=WeaponAnimLowReady_UMP
 IdleWeaponCategory=IdleWithUMP
-IronSightLocationOffset=(X=3,Y=-5.5,Z=4.25) 
+IronSightLocationOffset=(X=3,Y=-5.36,Z=4.15) 
 
 ;; GUI
 GUIImage=material'gui_tex.equip_Ump'
@@ -1347,7 +1361,8 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.M4A1_ThirdPerson'
 AimAnimation=WeaponAnimAim_M4
 LowReadyAnimation=WeaponAnimLowReady_M4
 IdleWeaponCategory=IdleWithMachineGun
-IronSightLocationOffset=(X=0,Y=-6.5,Z=3.65) 
+IronSightLocationOffset=(X=0,Y=-6.5,Z=3.7)
+IronSightRotationOffset=(Pitch=-70,Yaw=30,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_tex.equip_m4a1'
@@ -2061,6 +2076,10 @@ Bulk=22.22
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.M4Super90_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M4Super90_ThirdPerson'
+;IronSightLocationOffset=(X=1,Y=-7.40,Z=3.55) //to be used if idle animations enabled
+IronSightLocationOffset=(X=1,Y=-7.18,Z=3.67)
+;IronSightRotationOffset=(Pitch=80,Yaw=170,Roll=0) //to be used if idle animations enabled
+IronSightRotationOffset=(Pitch=-50,Yaw=140,Roll=0)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -2201,7 +2220,7 @@ Bulk=11.952
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.rem870_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.rem870_ThirdPerson'
-IronSightLocationOffset=(X=9.5,Y=-7.0,Z=1.1)
+IronSightLocationOffset=(X=9.5,Y=-6.7,Z=1.1)
 IronSightRotationOffset=(Pitch=800,Yaw=0,Roll=0)
 
 ;; Flashlight

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -185,7 +185,8 @@ Bulk=2.9337
 FirstPersonModelClass=class'SwatEquipmentModels2.ColtM1911_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.ColtM1911_ThirdPerson'
 UnequipAnimationRate=1.5
-IronSightLocationOffset=(X=0,Y=-7.1,Z=6.3)
+IronSightLocationOffset=(X=0,Y=-7.75,Z=2.0)
+IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -254,7 +255,8 @@ Bulk=2.5668
 GUIImage=material'gui_tex.equip_9mmpistol'
 WeaponCategory=WeaponClass_Pistol
 AllowedSlots=WeaponEquip_Either
-IronSightLocationOffset=(X=0,Y=-7.1,Z=6.3)
+IronSightLocationOffset=(X=0,Y=-7.9,Z=2.5)
+IronSightRotationOffset=(Pitch=780,Yaw=0,Roll=850)
 
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.NineMMpistol_FirstPerson'
@@ -572,6 +574,8 @@ Bulk=2.744
 FirstPersonModelClass=class'SwatEquipmentModels2.p226_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.p226_ThirdPerson'
 UnequipAnimationRate=1.5
+IronSightLocationOffset=(X=0,Y=-8,Z=2.8)
+IronSightRotationOffset=(Pitch=780,Yaw=0,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=true

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -36,6 +36,7 @@ PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
 IronSightLocationOffset=(X=0,Y=-7.5,Z=4.75) 
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ZoomedAimErrorModifier=0.75
+ViewInertia=0.85;
 ComplianceAnimation=Compliance_Handgun
 
 ;********************************
@@ -52,6 +53,7 @@ LowReadyAnimation=WeaponAnimLowReady_SubmachineGun
 IdleWeaponCategory=IdleWithSubmachineGun
 ZoomedFOV=60.0
 ZoomTime=0.25
+ViewInertia=0.65;
 ComplianceAnimation=Compliance_SubmachineGun
 
 [SwatEquipment.Handgun]
@@ -64,6 +66,7 @@ LowReadyAnimation=WeaponAnimLowReady_Handgun
 IdleWeaponCategory=IdleWithHandgun
 ZoomedFOV=60.0
 ZoomTime=0.25
+ViewInertia=0.55;
 ComplianceAnimation=Compliance_Handgun
 
 [SwatEquipment.MachineGun]
@@ -76,6 +79,7 @@ LowReadyAnimation=WeaponAnimLowReady_Machinegun
 IdleWeaponCategory=IdleWithG36
 ZoomedFOV=45.0
 ZoomTime=0.25
+ViewInertia=0.73;
 ComplianceAnimation=Compliance_MachineGun
 
 [SwatEquipment.Shotgun]
@@ -86,6 +90,7 @@ LightstickThrowAnimPostfix="SG"
 Choke=1.81
 ZoomedFOV=60.0
 ZoomTime=0.25
+ViewInertia=0.78;
 ; Handling qualities similar to shotguns (can be overridden)
 AimErrorBreakingPoint=4.0
 LookAimErrorPenaltyFactor=0.000125
@@ -102,6 +107,7 @@ LowReadyAnimation=WeaponAnimLowReady_Paintball
 IdleWeaponCategory=IdleWithPaintballGun
 ZoomedFOV=60.0
 ZoomTime=0.25
+ViewInertia=0.75;
 ComplianceAnimation=Compliance_CSBallLauncher
 
 [SwatEquipment.BeanbagShotgunBase]
@@ -131,6 +137,7 @@ IdleWeaponCategory=IdleWithG36
 ZoomedFOV=60.0
 ZoomTime=0.25
 ComplianceAnimation=Compliance_Shotgun
+ViewInertia=0.85;
 
 
 ;********************************
@@ -1105,7 +1112,7 @@ Bulk=17.68
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.MP5_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.MP5_ThirdPerson'
-IronSightLocationOffset=(X=0,Y=-6.5,Z=4.75) 
+IronSightLocationOffset=(X=0,Y=-5.8,Z=3.85) 
 
 ;; GUI
 GUIImage=material'gui_tex.equip_mp5'
@@ -1461,6 +1468,7 @@ Bulk=28.418
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.M16A1sd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M16A1sd_ThirdPerson'
+ViewInertia=0.8;
 
 ;; GUI FIXME
 GUIImage=material'gui_sas.m16a1sd'
@@ -1809,6 +1817,7 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.hk33s_ThirdPerson'
 ZoomBlurOverlay=Material'gui_sas.scope'
 ZoomedFOV=18
 ZoomTime=0.50
+ViewInertia=0.8;
 
 ;; GUI FIXME
 GUIImage=material'gui_sas.hk33s'

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -255,7 +255,7 @@ Bulk=2.5668
 GUIImage=material'gui_tex.equip_9mmpistol'
 WeaponCategory=WeaponClass_Pistol
 AllowedSlots=WeaponEquip_Either
-IronSightLocationOffset=(X=3,Y=-7.75,Z=2.7)
+IronSightLocationOffset=(X=3,Y=-7.7,Z=2.6)
 IronSightRotationOffset=(Pitch=640,Yaw=0,Roll=700)
 
 ;; Viewmodel and Zoom
@@ -327,9 +327,8 @@ AllowedSlots=WeaponEquip_Either
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.PythonRevolver_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.PythonRevolver_ThirdPerson'
-;TODO: not tuned yet
-IronSightLocationOffset=(X=0,Y=-7.65,Z=1.7)
-IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
+IronSightLocationOffset=(X=2,Y=-7.80,Z=5.7)
+IronSightRotationOffset=(Pitch=-230,Yaw=-20,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=false
@@ -456,9 +455,8 @@ Bulk=2.758
 FirstPersonModelClass=class'SwatEquipmentModels2.BrowHP_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.BrowHP_ThirdPerson'
 UnequipAnimationRate=1.5
-;TODO: not tuned yet
-IronSightLocationOffset=(X=0,Y=-7.65,Z=1.7)
-IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
+IronSightLocationOffset=(X=1,Y=-7.72,Z=3.56)
+IronSightRotationOffset=(Pitch=450,Yaw=-40,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=false
@@ -522,9 +520,8 @@ Bulk=4.018
 FirstPersonModelClass=class'SwatEquipmentModels2.BrowHPsd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.BrowHPsd_ThirdPerson'
 UnequipAnimationRate=1.5
-;TODO: not tuned yet
-IronSightLocationOffset=(X=0,Y=-7.65,Z=1.7)
-IronSightRotationOffset=(Pitch=880,Yaw=0,Roll=700)
+IronSightLocationOffset=(X=1,Y=-7.72,Z=3.56)
+IronSightRotationOffset=(Pitch=450,Yaw=-40,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=false
@@ -586,8 +583,8 @@ Bulk=2.744
 FirstPersonModelClass=class'SwatEquipmentModels2.p226_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.p226_ThirdPerson'
 UnequipAnimationRate=1.5
-IronSightLocationOffset=(X=0,Y=-8,Z=2.8)
-IronSightRotationOffset=(Pitch=780,Yaw=0,Roll=800)
+IronSightLocationOffset=(X=1.5,Y=-7.97,Z=2.86)
+IronSightRotationOffset=(Pitch=600,Yaw=0,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -655,6 +652,8 @@ Bulk=4.004
 FirstPersonModelClass=class'SwatEquipmentModels2.p226sd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.p226sd_ThirdPerson'
 UnequipAnimationRate=1.5
+IronSightLocationOffset=(X=1.5,Y=-7.97,Z=2.86)
+IronSightRotationOffset=(Pitch=600,Yaw=0,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -1278,7 +1277,8 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.UMP45_ThirdPerson'
 AimAnimation=WeaponAnimAim_UMP
 LowReadyAnimation=WeaponAnimLowReady_UMP
 IdleWeaponCategory=IdleWithUMP
-IronSightLocationOffset=(X=3,Y=-5.36,Z=4.15) 
+IronSightLocationOffset=(X=3,Y=-5.5,Z=4.0)
+IronSightRotationOffset=(Pitch=20,Yaw=0,Roll=100)
 
 ;; GUI
 GUIImage=material'gui_tex.equip_Ump'
@@ -1923,6 +1923,8 @@ Bulk=20.016
 ;; Viewmodel and zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.G36K_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.G36K_ThirdPerson'
+IronSightLocationOffset=(X=2,Y=-5.4,Z=3.9)
+IronSightRotationOffset=(Pitch=-130,Yaw=10,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_tex.equip_G36K'
@@ -2077,7 +2079,7 @@ Bulk=22.22
 FirstPersonModelClass=class'SwatEquipmentModels2.M4Super90_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M4Super90_ThirdPerson'
 ;IronSightLocationOffset=(X=1,Y=-7.40,Z=3.55) //to be used if idle animations enabled
-IronSightLocationOffset=(X=1,Y=-7.18,Z=3.67)
+IronSightLocationOffset=(X=2,Y=-7.18,Z=3.67)
 ;IronSightRotationOffset=(Pitch=80,Yaw=170,Roll=0) //to be used if idle animations enabled
 IronSightRotationOffset=(Pitch=-50,Yaw=140,Roll=0)
 
@@ -2150,6 +2152,8 @@ Bulk=21.516
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.NovaPump_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.NovaPump_ThirdPerson'
+IronSightLocationOffset=(X=1,Y=-6.65,Z=3)
+IronSightRotationOffset=(Pitch=400,Yaw=0,Roll=0)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -2220,7 +2224,7 @@ Bulk=11.952
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.rem870_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.rem870_ThirdPerson'
-IronSightLocationOffset=(X=9.5,Y=-6.7,Z=1.1)
+IronSightLocationOffset=(X=9.5,Y=-6.9,Z=1.1)
 IronSightRotationOffset=(Pitch=800,Yaw=0,Roll=0)
 
 ;; Flashlight
@@ -2306,6 +2310,8 @@ FirstPersonModelClass=class'SwatEquipmentModels2.HK69GL_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.HK69GL_ThirdPerson'
 AimAnimation=WeaponAnimAim_MachineGun
 LowReadyAnimation=WeaponAnimLowReady_MachineGun
+IronSightLocationOffset=(X=2,Y=-7.20,Z=5.20)
+IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 
 ;; Firing
 Range=6000
@@ -2385,6 +2391,8 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.Arwen37_ThirdPerson'
 AimAnimation=WeaponAnimAim_M4
 LowReadyAnimation=WeaponAnimLowReady_M4
 IdleWeaponCategory=IdleWithMachineGun
+IronSightLocationOffset=(X=1,Y=-6.5,Z=4)
+IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 
 ;; Flashlight
 HasAttachedFlashlight=True
@@ -2605,6 +2613,8 @@ FlashlightRotation_1stPerson=(Pitch=0,Yaw=0,Roll=0)
 FlashlightPosition_3rdPerson=(X=0,Y=-39.4,Z=1.15)
 FlashlightRotation_3rdPerson=(Pitch=0,Yaw=-16384,Roll=0)
 LightstickThrowAnimPostfix="SG"
+IronSightLocationOffset=(X=1,Y=-6.65,Z=3)
+IronSightRotationOffset=(Pitch=400,Yaw=0,Roll=0)
 
 Weight=3.89
 Bulk=21.516
@@ -2628,6 +2638,8 @@ Bulk=11.952
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.llrem870_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.llrem870_ThirdPerson'
+IronSightLocationOffset=(X=9.5,Y=-6.9,Z=1.1)
+IronSightRotationOffset=(Pitch=800,Yaw=0,Roll=0)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -2745,6 +2757,9 @@ FlashlightPosition_3rdPerson=(X=2.5,Y=-31.5,Z=6.6)
 FlashlightRotation_3rdPerson=(Pitch=0,Yaw=-16384,Roll=0)
 ;Weapon Zoom
 LightstickThrowAnimPostfix="SMG"
+IronSightLocationOffset=(X=1,Y=-7.5,Z=3)
+;hold it at severe angle so we can use our thumb as the sight
+IronSightRotationOffset=(Pitch=0,Yaw=-100,Roll=2600)
 
 Weight=2.44
 Bulk=17.68
@@ -2901,6 +2916,8 @@ WeaponCategory=WeaponClass_LessLethal
 AllowedSlots=WeaponEquip_Either
 AimAnimation=WeaponAnimAim_Handgun
 LowReadyAnimation=WeaponAnimLowReady_Handgun
+IronSightLocationOffset=(X=1,Y=-7.35,Z=3.65)
+IronSightRotationOffset=(Pitch=500,Yaw=0,Roll=500)
 
 ;********************************
 ;STINGRAY STUN GUN

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -48,7 +48,7 @@ ZoomedAimErrorModifier=0.75
 ;ViewInertia controls how much the weapon moves when you move, 
 ;and how quickly you can align the iron sights
 ;Valid range is 0 - 1
-ViewInertia=0.85;
+ViewInertia=0.5;
 ComplianceAnimation=Compliance_Handgun
 
 ;********************************
@@ -129,6 +129,7 @@ RagdollDeathImpactMomentumMultiplier=15
 LightstickThrowAnimPostfix="SG"
 ZoomedFOV=60.0
 ZoomTime=0.25
+ViewInertia=0.5;
 ; Handling qualities similar to shotguns (can be overridden)
 AimErrorBreakingPoint=4.0
 LookAimErrorPenaltyFactor=0.000125
@@ -1513,7 +1514,7 @@ Bulk=28.418
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.M16A1sd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M16A1sd_ThirdPerson'
-ViewInertia=0.8;
+ViewInertia=0.6;
 
 ;; GUI FIXME
 GUIImage=material'gui_sas.m16a1sd'
@@ -1862,7 +1863,7 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.hk33s_ThirdPerson'
 ZoomBlurOverlay=Material'gui_sas.scope'
 ZoomedFOV=18
 ZoomTime=0.50
-ViewInertia=0.8;
+ViewInertia=0.6;
 
 ;; GUI FIXME
 GUIImage=material'gui_sas.hk33s'

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -32,7 +32,8 @@ FirstPersonPreThrowAnimation=PullPin
 [Engine.SwatWeapon]
 PlayerViewOffset=(X=-22,Y=7,Z=-12)
 PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
-IronSightLocationOffset=(X=-22,Y=7,Z=-12)
+;IronSightLocationOffset=(X=-22,Y=7,Z=-12)
+IronSightLocationOffset=(X=0,Y=-7.5,Z=4.75) 
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ZoomedAimErrorModifier=0.75
 ComplianceAnimation=Compliance_Handgun
@@ -1104,6 +1105,7 @@ Bulk=17.68
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.MP5_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.MP5_ThirdPerson'
+IronSightLocationOffset=(X=0,Y=-6.5,Z=4.75) 
 
 ;; GUI
 GUIImage=material'gui_tex.equip_mp5'

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -37,8 +37,11 @@ FirstPersonPreThrowAnimation=PullPin
 [Engine.SwatWeapon]
 PlayerViewOffset=(X=-22,Y=7,Z=-12)
 PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
-;Controls position of the weapon when you aim down sights
+;Controls position of weapon when you aren't aiming down sights
 ;X = forward/backwards, Y = Right / Left, Z = Up / Down
+DefaultLocationOffset=(X=0,Y=0,Z=0)
+DefaultRotationOffset=(Pitch=0,Yaw=0,Roll=0)
+;Controls position of the weapon when you aim down sights
 IronSightLocationOffset=(X=1,Y=-7.40,Z=4.65)
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ZoomedAimErrorModifier=0.75
@@ -792,6 +795,8 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.P90_ThirdPerson'
 AimAnimation=WeaponAnimAim_P90
 LowReadyAnimation=WeaponAnimLowReady_P90
 IdleWeaponCategory=IdleWithP90
+DefaultLocationOffset=(X=6,Y=-1,Z=5)
+DefaultRotationOffset=(Pitch=0,Yaw=0,Roll=1100)
 IronSightLocationOffset=(X=6,Y=-7.0,Z=3.4)
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=1200)
 

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -1,3 +1,8 @@
+;Values lower in the file will override values higher in the file
+;For example, values in [SwatEquipment.SubMachineGun] will override 
+;values in [Engine.SwatWeapon], and values in [SwatEquipment.MP5SSDSMG]
+;will override values in [SwatEquipment.SubMachineGun]
+
 [Engine.HandheldEquipment]
 ZoomTime=0.5
 
@@ -32,6 +37,8 @@ FirstPersonPreThrowAnimation=PullPin
 [Engine.SwatWeapon]
 PlayerViewOffset=(X=-22,Y=7,Z=-12)
 PlayerViewRotator=(Pitch=0,Yaw=0,Roll=0)
+;Controls position of the weapon when you aim down sights
+;X = forward/backwards, Y = Right / Left, Z = Up / Down
 IronSightLocationOffset=(X=0,Y=-7.5,Z=4.75) 
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 ZoomedAimErrorModifier=0.75

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -917,6 +917,7 @@ Bulk=17.42
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.mp5sd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.mp5sd_ThirdPerson'
+IronSightLocationOffset=(X=0,Y=-6.1,Z=5.35)
 
 ;; GUI
 GUIImage=material'gui_sas.mp5sd_gui'
@@ -1131,7 +1132,7 @@ Bulk=17.68
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.MP5_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.MP5_ThirdPerson'
-IronSightLocationOffset=(X=0,Y=-5.8,Z=3.85) 
+IronSightLocationOffset=(X=2,Y=-5.8,Z=3.85) 
 
 ;; GUI
 GUIImage=material'gui_tex.equip_mp5'
@@ -1200,6 +1201,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SDSMG_JHP",Chance=20)
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.SilencedMP5_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.SilencedMP5_ThirdPerson'
+IronSightLocationOffset=(X=2,Y=-5.8,Z=3.85) 
 
 ;; Weight and Bulk
 Weight=2.78


### PR DESCRIPTION
#These commits add a basic working iron sight implementation to the game. They build on the code that @jose21crisis was working on for iron sights, but I simplified the code and added some new features.

You will move the weapon to look down its sights when you press the 'zoom' key. In addition to support for aiming down the sights, I also added a `ViewInertia` property to weapons. The `ViewInertia` property controls how responsive the weapon is when you move. A weapon with a higher inertia will sway to the sides more when you turn, and will take longer for you to align the iron sights. 

Of course SWAT 4 wasn't designed with iron sights in mind, and there are some issues. It might be better to make this a separate branch. 

## Updates
- 4-21-17: Added support for iron sight rotation offset. Set the rotation and location offsets for 1911, Glock, P226, MP5ks, and M870
- 4-24-17: Idle animations are disabled while aiming down sight. Added support for suppressed MP5, MP5SD6, and M4 Super 90. (MP5SD6 is unusable due to animation issues)
- 4-27-17: Added console commands for adjusting the iron sight parameters for the active weapon, useful for calibrating the weapons more quickly. **Finished calibrating all campaign weapons**. Added support for separate location/rotation offsets for when you aren't aiming down sight, so I could fix the damn P90.
- 5-02-17: Aim-down-sight speed partially separated from inertia so I could reduce the inertia for all weapons without speeding up the ADS animation
- 5-04-17: Fixed inertia/ADS speed being affected by framerate

## Console commands
The effects of each of these commands lasts until the current mission ends. They are intended to help with deciding upon final values to put in SwatEquipment.ini. **Note that you must have a space between the command and the values, and cannot have any spaces within the parentheses.**
- `SetIronSightOffset (x=0,y=0,z=0)` - adjust the position of the iron sights
- `SetIronSightRotation (pitch=0,yaw=0,roll=0)` - adjust the rotation of the iron sights. Note that adjusting the pitch or yaw will have a *severe* impact on the position; in other words, you'll need to adjust the offset a lot to compensate
- `SetWeaponViewOffset (x=0,y=0,z=0)` - adjust the position of the weapon when not aiming down sight
- `SetWeaponViewRotation (pitch=0,yaw=0,roll=0)` - adjust the rotation of the weapon when not aiming down sight
- `SetWeaponViewInertia 0.5` - adjust the view inertia of the weapon (how much it moves around and how fast you raise and lower the sights). The range is 0 - 1, but good values range from about 0.5 to 0.85. Use larger values for heavier weapons.

## Known Issues
- The weapon models tend to clip through the camera if you run forward while aiming down sight
- ~~The weapon idle animations make it difficult to aim. Hopefully there's an easy way to tone them down or disable them when you're aiming down the sights~~
  -  After idle animations are disabled, they are not re-enabled until you change weapons or move the crosshair over a target that causes you to lower your weapon (e.g. another officer)
- Since the view models were never intended to be used with iron sights, many of the weapons are missing faces on the right side of the weapon. Depending on the weapon and how quickly you are turning, you might be able to see holes in the right side of the gun.
- Inertia values will probably need lots of fine-tuning
- Crosshair still appears on top of sights
- The default MP5SD6 animations can't be used with iron sights, because the fingers are wrapped so far around the barrel that they block the sights 
- The HK33A2 can't be used with iron sights because it has a... flashlight? attached where a scope would be, completely obscuring the sights. Huh?