### PR TITLE
SwatEnemy: fix logging for the DropActiveWeapon chain

### DIFF
--- a/Source/Game/SwatGame/Classes/AI/SwatEnemy.uc
+++ b/Source/Game/SwatGame/Classes/AI/SwatEnemy.uc
@@ -685,8 +685,10 @@ simulated final function DropActiveWeapon(optional vector WeaponSpaceDropDirecti
 {
 	local HandheldEquipment ActiveItem;
 	
+	mplog( self$"---SwatEnemy::DropActiveWeapon()." );
+	
 	if ( Level.IsCoopServer )
-        NotifyClientsToDropActiveWeapon();
+		NotifyClientsToDropActiveWeapon();
 
 	ActiveItem = GetActiveItem();
 	
@@ -782,7 +784,7 @@ function NotifyClientsToDropActiveWeapon()
 
     Assert( Level.NetMode == NM_ListenServer || Level.NetMode == NM_DedicatedServer );
 
-    mplog( self$"$---SwatEnemy::NotifyClientsToDropAllWeapons()." );
+    mplog( self$"$---SwatEnemy::NotifyClientsToDropActiveWeapon()." );
 
     theLocalPlayerController = Level.GetLocalPlayerController();
     for ( i = Level.ControllerList; i != None; i = i.NextController )


### PR DESCRIPTION
To make it easier to diagnose #191 . Doesn't _fix_ #191 yet (or at least it shouldn't). Will update PR if I figure out the fix.