### PR TITLE
Fix the breaching shotgun behavior

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/UseBreachingShotgunAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/UseBreachingShotgunAction.uc
@@ -211,14 +211,14 @@ latent function BreachDoorWithShotgun()
 	ISwatDoor(TargetDoor).UnRegisterInterestedInDoorOpening(self);
 
 	BreachingShotgun.SetPerfectAimNextShot();
+	
+	// @HACK Break the door "before firing the shotgun. The AI literally always misses,
+	// and there is a very noticable delay if we automatically break the door AFTER firing 
+	// the shotgun, but if we break the door FIRST it appears to happen exactly when the 
+	// shot is fired. In other words, this solution looks perfect. -K.F. 
+	
+	ISwatDoor(TargetDoor).Blasted(m_Pawn);
 	BreachingShotgun.LatentUse();
-
-	// @HACK: If the door wasn't broken by the breaching shotgun, blast it anyways.
-	if (! ISwatDoor(TargetDoor).IsBroken())
-	{
-		BreachingShotgun.LatentUse();
-		ISwatDoor(TargetDoor).Blasted(m_Pawn);
-	}
 }
 
 function TriggerReportedDeployingShotgunSpeech()


### PR DESCRIPTION
Change the UseBreachingShotgunAction so that the door breaks immediately _before_ the AI fires the shotgun. This sounds dumb, but it actually looks perfect since the AI fires instantly afterward and both actions appear to happen simultaneously to the player. This is a much better solution than checking if the AI missed the door and then breaking the door, both because the AI literally always misses, and because there is a very noticeable delay if we don't break the door until after they fire. 

Puts #210 into custody.