### PR TITLE
Increased flashlight range

### DIFF
--- a/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
+++ b/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
@@ -5768,6 +5768,33 @@ exec function TestClientMessage( name type, string Msg )
     ClientMessage( Msg, type );
 }
 
+/* 
+//For debugging. These can be considered cheats and probably should
+be moved to SwatCheatManager
+exec function SetFlashlightRadius(float radius)
+{
+	local HandheldEquipment ActiveItem;
+	local FiredWeapon ActiveWeapon;
+	
+	ActiveItem = Pawn.GetActiveItem();
+	ActiveWeapon = FiredWeapon(ActiveItem);
+	if (ActiveWeapon != None) {
+		ActiveWeapon.SetFlashlightRadius(radius);
+	}
+}
+exec function SetFlashlightCone(float cone)
+{
+	local HandheldEquipment ActiveItem;
+	local FiredWeapon ActiveWeapon;
+	
+	ActiveItem = Pawn.GetActiveItem();
+	ActiveWeapon = FiredWeapon(ActiveItem);
+	if (ActiveWeapon != None) {
+		ActiveWeapon.SetFlashlightCone(cone);
+	}
+}
+*/
+
 #if IG_SWAT_AUDIT_FOCUS
 //causes an audit of the PlayerFocusInterfaces for one call to UpdateFocus()
 exec function AuditFocus()

--- a/Source/Unreal/Engine/Classes/Equipment/FiredWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/FiredWeapon.uc
@@ -1833,6 +1833,20 @@ simulated function UpdateFlashlightState()
     }
 }
 
+simulated function SetFlashlightRadius(float radius)
+{
+	if (FlashlightDynamicLight != None) {
+		FlashlightDynamicLight.LightRadius = radius;
+	}
+}
+
+simulated function SetFlashlightCone(float cone)
+{
+	if (FlashlightDynamicLight != None) {
+		FlashlightDynamicLight.LightCone = cone;
+	}
+}
+
 simulated private function UpdateFlashlightLighting(optional float dTime)
 {
 #if ENABLE_FLASHLIGHT_PROJECTION_VISIBILITY_TESTING
@@ -2033,8 +2047,13 @@ simulated private function InitFlashlight()
 	// if we have a higher-end graphics card, then use a spotlight, otherwise,
 	// use a pointlight and try to make it look a little like a spot light by
 	// moving it out from the gun barrel
-	if (FlashlightUseFancyLights == 1)
+	if (FlashlightUseFancyLights == 1) 
+	{
 		FlashlightDynamicLight = Spawn(FlashlightSpotLightClass,WeaponModel,,,);
+		//FlashlightDynamicLight.bActorShadows = true; //doesn't seem to work
+		FlashlightDynamicLight.LightCone = 8; //how wide the flashlight beam is
+		FlashlightDynamicLight.LightRadius = FlashlightFirstPersonDistance; //distance the beam travels
+	}
 	else
 		FlashlightDynamicLight = Spawn(FlashlightPointLightClass,WeaponModel,,,);
 


### PR DESCRIPTION
The default flashlight settings have an unrealistically short range, Greatly increased the range of the 'fancy' (spotlight) flashlight and made the flashlight cone narrower