### PR TITLE
Reduced 'lost contact' spam

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/OfficerCommanderAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/OfficerCommanderAction.uc
@@ -201,7 +201,7 @@ function OnPawnLostVisionNotification()
 	assert(VisionSensor.LastPawnLost != None);
 
 	// just let the hive know
-	GetHive().OfficerLostPawn(m_Pawn, VisionSensor.LastPawnLost);
+	GetHive().OfficerLostPawn(m_Pawn, VisionSensor.LastPawnLost, VisionSensor.GetWasLostRecently(m_Pawn, VisionSensor.LastPawnLost));
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Don't play the 'lost contact with suspect' audio if the suspect is not a currently assigned target of any of the AI, or if we have previously lost contact with the same suspect in the last few seconds. Also don't play 'suspect spotted' audio if the suspect is currently the assigned target of an AI. Reduces speech spam and possibly fixes #185