### PR TITLE
Improved High-quality shadows

### DIFF
--- a/Source/Game/SwatGame/Classes/SwatPawn.uc
+++ b/Source/Game/SwatGame/Classes/SwatPawn.uc
@@ -285,9 +285,25 @@ replication
 
 simulated event PostBeginPlay()
 {
+    local int ShadowDetail;
+	local string ShadowDetailString;
+    
     log( self$"---SwatPawn::PostBeginPlay()." );
 
     Super.PostBeginPlay();
+
+    //New for the "High" shadow quality setting. -K.F.
+    ShadowDetailString = Level.GetLocalPlayerController().ConsoleCommand( "SHADOWDETAIL GET" );
+    ShadowDetail = int(ShadowDetailString);
+	// bAcceptsShadowProjectors cannot be set using any kind of conditional logic. 
+	// You can't do "if (ShadowDetail >= 3) bAcceptsShadowProjectors = true;"
+	// You can't do "if (ShadowDetailString == "3") bAcceptsShadowProjectors = true;"
+	// You can't do "bAcceptsShadowProjectors = (ShadowDetail > 3)"
+	// Any such approach will set the value, but the value will not be *applied*. 
+	// Don't believe me? Try it. Anyway, it is safe to always set this to true, since 
+	// it will only have an effect when ShadowProjector's bProjectActor property is true 
+	//   -K.F.
+	bAcceptsShadowProjectors = true; 
 
     if (bActorShadows && Level.NetMode != NM_DedicatedServer)
     {
@@ -302,10 +318,16 @@ simulated event PostBeginPlay()
         Shadow.CullDistance = ShadowCullDistance;
         Shadow.Resolution = 256;
         Shadow.InitShadow();
+        
+        if (ShadowDetail >= 3) //3 = "High"
+        {
+            Shadow.Resolution = 512;
+            //Level.GetLocalPlayerController().ConsoleMessage("High quality shadows enabled!");
+        }
     }
-
+    
     // Initialize the perlin noise object for mouth movement
-        InitAnimationForCurrentMesh();
+    InitAnimationForCurrentMesh();
     InitMouthMovementPerlinNoise();
 }
 

--- a/Source/Unreal/Engine/Classes/Equipment/HandheldEquipmentModel.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/HandheldEquipmentModel.uc
@@ -713,8 +713,7 @@ defaultproperties
     RemoteRole=ROLE_None
     DrawType=DT_Mesh
 
-    // To speed up rendering, don't let pawn shadows be cast on equipment
-    bAcceptsShadowProjectors=false
+    bAcceptsShadowProjectors=true
 
     // these should be part of the 3rd person shadows
     bActorShadows=true

--- a/Source/Unreal/Engine/Classes/ShadowProjector.uc
+++ b/Source/Unreal/Engine/Classes/ShadowProjector.uc
@@ -31,7 +31,16 @@ native final function UpdateDetailSetting();
 
 event PostBeginPlay()
 {
+	local int ShadowDetail;
+
 	Super(Actor).PostBeginPlay();
+	
+	//New "High"-quality shadow quality setting. Enables casting shadows on actors. -K.F.
+	ShadowDetail = int(Level.GetLocalPlayerController().ConsoleCommand( "SHADOWDETAIL GET" ) );
+	if (ShadowDetail >= 3) //3 = "high"
+	{
+		bProjectActor = true;
+	}
 }
 
 //


### PR DESCRIPTION
"High" quality setting for Dynamic Shadows now uses higher resolution shadow projectors, and allows shadows to be cast on pawns and equipment. This greatly enhances visual quality, without notable performance impact on modern GPUs.

![newshadowsettings](https://cloud.githubusercontent.com/assets/7231744/26393513/e6ed9b84-401e-11e7-9883-5a5aa7219d56.png)


Note: I tried adding a new "Very High" setting for Dynamic Shadows, but the engine seems to be hardcoded to only support the original quality settings. As far as I can tell, when you pick a video setting, it is stored in memory as a string representation of the index of the setting (e.g. "3" means "High"). When you quit SWAT 4, the engine converts the index to a quality string (`Off`, `Low`, `Medium`, or `High`). You can edit the language files to add "Very High" to the "Dynamic Shadow Quality" dropdown, but if you pick "Very High", it will save that setting as `(INVALID)` and the setting will default to "Medium" on the next launch.

Also note that `bAcceptsShadowProjectors` cannot be set to `true` with conditional logic. The value gets set, but the setting isn't applied. It must be an engine quirk.
