### PR TITLE
Added support for third previously unused blood decal

### DIFF
--- a/System/VisualEffects.ini
+++ b/System/VisualEffects.ini
@@ -3294,10 +3294,14 @@ Specification=(SpecificationType=AK471stPersonEffects,SpecificationClass=Class'I
 [AmmunitionBloodProjected]
 Event=BloodProjected
 SourceClassName=Ammunition
-Chance=50
+Chance=33
 Specification=(SpecificationType=BloodProjected,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
-Chance=50
+Chance=33
 Specification=(SpecificationType=BloodProjectedB,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+Chance=34
+Specification=(SpecificationType=BloodProjectedC,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+;Chance=25
+;Specification=(SpecificationType=BloodProjectedD,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
 
 [GUIcarAlive_Dust]
 Event=Alive
@@ -5850,6 +5854,20 @@ Precache=True
 AttachToSource=False
 MaterialType=MVT_Default
 EffectClass=class'SwatEffects.Blood4Decal'
+
+[BloodProjectedC]
+ClassName=Class'IGVisualEffectsSubsystem.VisualEffectSpecification'
+Precache=True
+AttachToSource=False
+MaterialType=MVT_Default
+EffectClass=class'SwatEffects.Blood2Decal'
+
+;[BloodProjectedD]
+;ClassName=Class'IGVisualEffectsSubsystem.VisualEffectSpecification'
+;Precache=True
+;AttachToSource=False
+;MaterialType=MVT_Default
+;EffectClass=class'SwatEffects.Blood3Decal'
 
 [REPOhelicopterDust]
 ClassName=Class'IGVisualEffectsSubsystem.VisualEffectSpecification'


### PR DESCRIPTION
Add support for a third, previously unused blood decal `Blood2Decal`. This decal seems to be a bit larger and has more of a 'splat' look to it (as opposed to the "mist" look of the other two decals).

I gave the Blood2Decal the same chance to appear as the other two decals. Since it is slightly larger and more noticeable, you can in theory slightly ramp up the overall gore level by increasing the chance of getting Blood2Decal relative to the other decals.

Note that the file names imply there is a Blood3Decal, but trying to include Blood3Decal causes the game to throw errors whenever you shoot someone, so I have commented it out.

![blooddecals](https://cloud.githubusercontent.com/assets/7231744/26480448/abbe4b50-418e-11e7-9623-86c48b4821ce.png)
_several suspects were harmed in the making of these screenshots_