### PR TITLE
Bunch Of Ai Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ Once you have selected your map settings and have started the server at least on
 - Externalized the position of the weapon in first person and in iron sights.
 - LaunchSEF.exe now works correctly on Windows XP.
 - Cut Content Restored: M1Super90 Defense shotgun added
+- Cut Content Restored: Enemies will now use the unused "ReportedBarricading" lines.
 - Fixed SEF bug: AI-controlled officers would try and take cover when an enemy was at point-blank range, instead of firing at them.
 - Fixed SEF bug: Wedges not depleting weight when used
 - Fixed SEF bug: AI-controlled officers were more focused on falling in than engaging suspects at times.
@@ -782,6 +783,8 @@ Once you have selected your map settings and have started the server at least on
 - Fixed TSS bug: Lightsticks don't drop if the player is wearing heavy armor
 - Fixed TSS bug: If a suspect unlocks a door, it will still be "known" as a locked door.
 - Fixed TSS bug: Pathing error with Jackson on Fairfax Residence, videotape room
+- Fixed TSS bug: The enemy "CallForHelp" speech was rarely/if at all triggering.
+- Fixed TSS bug: The enemy "AnnouncedSpottedOfficerSurprised" speech now plays.
 
 ### v5.3 ###
 Special thanks to kevinfoley, who made a lot of changes here. His contributions are marked with [kf]

--- a/Source/Game/SwatAICommon/Classes/Actions/BarricadeAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/BarricadeAction.uc
@@ -400,6 +400,8 @@ latent function LockDoor(Door TargetDoor)
 		CurrentMoveToDoorGoal.SetWalkThreshold(0.0);
 
 		CurrentMoveToDoorGoal.postGoal(self);
+		// do some speech
+		ISwatEnemy(m_Pawn).GetEnemySpeechManagerAction().TriggerBarricadeSpeech();
 		WaitForGoal(CurrentMoveToDoorGoal);
 		CurrentMoveToDoorGoal.unPostGoal(self);
 
@@ -557,7 +559,7 @@ Begin:
 	// trigger the barricade speech based on a die roll
 	if (FRand() < ReactionSpeechChance)
 	{
-		ISwatEnemy(m_Pawn).GetEnemySpeechManagerAction().TriggerBarricadeSpeech();
+		ISwatEnemy(m_Pawn).GetEnemySpeechManagerAction().TriggerBarricadingSpeech();
 	}
 
 	// crouch if we're supposed to

--- a/Source/Game/SwatAICommon/Classes/Actions/EnemySpeechManagerAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/EnemySpeechManagerAction.uc
@@ -16,9 +16,16 @@ function TriggerOfficerEncounteredSpeech()
 		TriggerSpeech('AnnouncedSpottedOfficerSurprised');
 	}
 	else if (! ISwatAI(m_Pawn).IsAggressive() && (ISwatEnemy(m_Pawn).GetEnemySkill() < EnemySkill_High))
-	{
-		TriggerSpeech('AnnouncedSpottedOfficerScared');
-	}
+    {
+        if (FRand() < 0.5)
+        {
+            TriggerSpeech('AnnouncedSpottedOfficerScared');
+        }
+        else
+        {
+            TriggerSpeech('AnnouncedSpottedOfficerSurprised');
+        }
+    }
 	else
 	{
 		TriggerSpeech('AnnouncedSpottedOfficer');
@@ -53,6 +60,12 @@ function TriggerInvestigateSpeech()
 function TriggerBarricadeSpeech()
 {
 	TriggerSpeech('AnnouncedBarricade', true);
+}
+
+// Such a creative name I know -sandman332
+function TriggerBarricadingSpeech()
+{
+	TriggerSpeech('ReportedBarricading', true);
 }
 
 function TriggerUncompliantSpeech()

--- a/Source/Game/SwatAICommon/Classes/Actions/FleeAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/FleeAction.uc
@@ -400,9 +400,13 @@ latent function Flee()
 
     // post the move to goal and wait for it to complete
     CurrentMoveToActorGoal.postGoal(self);
+
+	// trigger the speech
+	ISwatEnemy(m_Pawn).GetEnemySpeechManagerAction().TriggerCallForHelpSpeech();
+
     WaitForGoal(CurrentMoveToActorGoal);
 
-    // remove the most to goal
+    // remove the move to goal
     CurrentMoveToActorGoal.unPostGoal(self);
 	CurrentMoveToActorGoal.Release();
 	CurrentMoveToActorGoal = None;


### PR DESCRIPTION
- Enemies now have a 50% chance to either play the announced officer scared speech, or the announced officer surprised speech.  Currently, no idea why the surprised speech isn't triggering.  What jose did sadly did not fix it.

- Also added in the missing "ReportedBarricading" line to the speech manager

- Suspects won't fire while regrouping if they can not hit their target.  (This was done to the flee action but not the regroup action)

- Fixed a spelling mistake in the regroupaction. 

- Enemies will now properly play the call for help speech when regrouping.  I also added this to the flee function as well.