### PR TITLE
Aim down scope animation

### DIFF
--- a/Source/Unreal/Engine/Classes/Equipment/Hands.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Hands.uc
@@ -98,12 +98,15 @@ simulated function UpdateHandsForRendering()
     local vector Change;
     local float DeltaTime;
     local vector Velocity, Acceleration;
-	local float MaxInertiaOffset;
+    local float MaxInertiaOffset;
+	local SwatWeapon Weapon;
 
     OwnerPawn = Pawn(Owner);
     OwnerController = PlayerController(OwnerPawn.Controller);
     DeltaTime = OwnerController.LastDeltaTime;
     HandsPass.Length = HandAnimationPass.EnumCount;
+    
+    bOwnerNoSee = !OwnerPawn.bRenderHands || OwnerController.GetViewmodelDisabled();
 
     EquippedItem = OwnerPawn.GetActiveItem();
     if (EquippedItem != None)
@@ -111,7 +114,7 @@ simulated function UpdateHandsForRendering()
         EquippedFirstPersonModel = EquippedItem.FirstPersonModel;
         if (EquippedFirstPersonModel != None)
         {
-            EquippedFirstPersonModel.bOwnerNoSee = !OwnerPawn.bRenderHands || OwnerController.GetViewmodelDisabled();
+            EquippedFirstPersonModel.bOwnerNoSee = bOwnerNoSee;
         }
     }
 
@@ -140,6 +143,11 @@ simulated function UpdateHandsForRendering()
     	//HACK: offset when the player isn't using iron sights, to fix the ******* P90 -K.F.
     	//NewRotation += EquippedItem.GetDefaultRotationOffset();
     	Offset = EquippedItem.GetDefaultLocationOffset();
+    }
+    
+    Weapon = SwatWeapon(EquippedItem);
+    if (Weapon != None && Weapon.WeaponCategory == WeaponClass_MarksmanRifle && !bOwnerNoSee) {
+        EquippedFirstPersonModel.bOwnerNoSee = (AnimationProgress >= 0.99);
     }
 
     //scale animation position change based on framerate
@@ -186,8 +194,6 @@ simulated function UpdateHandsForRendering()
     {
         NewLocation = TargetLocation;
     }
-
-    bOwnerNoSee = !OwnerPawn.bRenderHands || OwnerController.GetViewmodelDisabled();
 
     // Special-case exception: even if hands/weapon rendering is disabled,
     // the hands and weapon should be shown when the optiwand is equipped

--- a/Source/Unreal/Engine/Classes/Equipment/Hands.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Hands.uc
@@ -145,9 +145,11 @@ simulated function UpdateHandsForRendering()
     	Offset = EquippedItem.GetDefaultLocationOffset();
     }
     
+	//look-down-scope animation for marksman (scoped) weapons
     Weapon = SwatWeapon(EquippedItem);
     if (Weapon != None && Weapon.WeaponCategory == WeaponClass_MarksmanRifle && !bOwnerNoSee) {
         EquippedFirstPersonModel.bOwnerNoSee = (AnimationProgress >= 0.99);
+		bHidden = (AnimationProgress >= 0.99);
     }
 
     //scale animation position change based on framerate

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -880,7 +880,7 @@ Bulk=14.04
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.Uzi_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.UZI_ThirdPerson'
-DefaultLocationOffset=(X=5,Y=0,Z=2)
+DefaultLocationOffset=(X=4,Y=0,Z=2)
 DefaultRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 IronSightLocationOffset=(X=6,Y=-6.1,Z=3.7)
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
@@ -1979,7 +1979,7 @@ ZoomBlurOverlay=Material'gui_sas.scope'
 ZoomedFOV=18
 ZoomTime=0.50
 ViewInertia=0.6
-IronSightLocationOffset=(X=0,Y=0,Z=0)
+IronSightLocationOffset=(X=0,Y=-7.5,Z=3)
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 
 ;; GUI FIXME
@@ -2175,8 +2175,9 @@ ZoomBlurOverlay=Material'gui_tex2.AR15_SniperScopeShader'
 AimAnimation=WeaponAnimAim_MachineGun
 LowReadyAnimation=WeaponAnimLowReady_MachineGun
 IdleWeaponCategory=IdleWithG36
-IronSightLocationOffset=(X=0,Y=0,Z=0)
+IronSightLocationOffset=(X=1,Y=-7.3,Z=4)
 IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
+ViewInertia=0.55;
 
 ;; Flashlight
 HasAttachedFlashlight=False

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -880,8 +880,10 @@ Bulk=14.04
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.Uzi_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.UZI_ThirdPerson'
-IronSightLocationOffset=(X=0,Y=-6.08,Z=3.63)
-IronSightRotationOffset=(Pitch=25,Yaw=25,Roll=0)
+DefaultLocationOffset=(X=5,Y=0,Z=2)
+DefaultRotationOffset=(Pitch=0,Yaw=0,Roll=0)
+IronSightLocationOffset=(X=6,Y=-6.1,Z=3.7)
+IronSightRotationOffset=(Pitch=0,Yaw=0,Roll=0)
 
 ;; Flashlight
 HasAttachedFlashlight=false


### PR DESCRIPTION
When user presses "aim" while holding a marksman rifle, plays an animation of raising the scope to look down it. This is done by animating the scope to the center of the screen (using the iron sight code) and then hiding the viewmodel when the animation finishes).

<s>**BUG**: the player's hands aren't hidden yet. I thought I could hide them by calling `OwnerPawn.bRenderHands = false` but that didn't seem to work so I removed that part.</s>


