### PR TITLE
Officer wont get in idle after picking a lock

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/PickLockAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/PickLockAction.uc
@@ -294,8 +294,11 @@ state Running
 
 		MoveToPostPickLockLocation();
 		RotateToPostPickLockRotation();
+		
+		pause(); 	// So officers wont get in idle after picking
+		
 	}
-
+	
 	succeed();
 }
 

--- a/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadPlaceWedgeAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadPlaceWedgeAction.uc
@@ -98,7 +98,7 @@ Begin:
 
 	PlaceWedge();
 
-    StackUpOfficer(OfficerWithWedge, OfficerWithWedgeStackupPoint);
+    	StackUpSquad(true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadRemoveWedgeAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadRemoveWedgeAction.uc
@@ -55,7 +55,7 @@ Begin:
 
 	RemoveWedge(GetFirstOfficer());
 
-	StackUpOfficer(GetFirstOfficer(), StackUpPoints[0]);
+	StackUpSquad(true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Officers will remain in stack up position after unlocking a door with the toolkit