### PR TITLE
Contextual crosshairs visible when weapon crosshairs disabled

### DIFF
--- a/Source/Game/SwatGame/Classes/HUD/HUDPageBase.uc
+++ b/Source/Game/SwatGame/Classes/HUD/HUDPageBase.uc
@@ -171,7 +171,14 @@ function OnTick( float Delta )
 {
   if(PlayerOwner().GetCrosshairDisabled() || bInCinematic)
   {
-    Reticle.Hide();
+    if(Reticle.CenterPreviewImage != None) // is pointing at a 'hotspot' on a door
+    {
+      Reticle.Show();
+    }
+    else
+    {
+      Reticle.Hide();
+    }
   }
   else
   {


### PR DESCRIPTION
Fixes issue: https://github.com/eezstreet/SWATEliteForce/issues/515