### PR TITLE
Better pre-set MP filters

### DIFF
--- a/System/SwatGuiState.ini
+++ b/System/SwatGuiState.ini
@@ -34,7 +34,7 @@ CurrentDifficulty=DIFFICULTY_Hard
 bShowHelp=True
 bAlwaysRun=True
 bShowCustomSkins=True
-theServerFilters=(MaxPing=-1,bFull=False,bEmpty=False,bPassworded=False,bFilterGametype=False,GameType=MPM_BarricadedSuspects,bFilterMapName=False,MapName="",bHideIncompatibleVersions=False,bHideIncompatibleMods=False)
+theServerFilters=(MaxPing=-1,bFull=False,bEmpty=False,bPassworded=False,bFilterGametype=False,GameType=MPM_BarricadedSuspects,bFilterMapName=False,MapName="",bHideIncompatibleVersions=False,bHideIncompatibleMods=True)
 LastMissionPlayedCustomScenario=None
 bEverRanTraining=True
 PreferredVoiceType=VOICETYPE_Random
@@ -47,7 +47,7 @@ MPName=Player
 bShowSubtitles=False
 MessageDisplayTime=15
 AdminPassword=
-bViewingGameSpy=False
+bViewingGameSpy=True
 NetworkConnectionChoices=Modem
 NetworkConnectionChoices=ISDN
 NetworkConnectionChoices=Cable/ADSL


### PR DESCRIPTION
Most of the games are played on the Internet, so you should choose Internet as default. It can also confuse beginners if LAN is the default and no servers are shown. 
Also the default setting is now to show only SEF servers for a better overview.
![769679679](https://user-images.githubusercontent.com/65263210/92029762-4f3bfd00-ed66-11ea-9809-59f2eff52f25.png)
