### PR TITLE
Adjusted Penalties

### DIFF
--- a/System/Leadership.ini
+++ b/System/Leadership.ini
@@ -141,14 +141,14 @@ PenaltyPerHostage=-50
 [SwatProcedures.Procedure_NoOfficerIncapacitated]
 ;Localized TMC TODO move to .int when localization works
 Description=Incapacitated a fellow officer
-ChatMessage=Penalty: [c=ffff00]Incapacitated Officer (-25)[\c]
-PenaltyPerOfficer=-25
+ChatMessage=Penalty: [c=ffff00]Incapacitated Officer (-50)[\c]
+PenaltyPerOfficer=-50
 
 [SwatProcedures.Procedure_NoOfficerInjured]
 ;Localized TMC TODO move to .int when localization works
 Description=Injured a fellow officer
-ChatMessage=Penalty: [c=ffff00]Injured Officer (-10)[\c]
-PenaltyPerOfficer=-10
+ChatMessage=Penalty: [c=ffff00]Injured Officer (-15)[\c]
+PenaltyPerOfficer=-15
 
 [SwatProcedures.Procedure_NoUnauthorizedUseOfDeadlyForce]
 ;Localized TMC TODO move to .int when localization works
@@ -169,7 +169,7 @@ PenaltyPerEscapee=-5
 
 [SwatProcedures.Procedure_NoOfficerTased]
 Description=Tased a fellow officer
-PenaltyPerInfraction=-5
+PenaltyPerInfraction=-15
 
 [SwatProcedures.Procedure_NoTrapsTriggered]
 Description=Tripped a trap


### PR DESCRIPTION
The main reason for this pull request is that the penalties correspond more to reality. And that the points can be abused less. I think it is important that activities against your team are punished more, so that you respect each other. I think this is important for the sef coop gameplay.
Shooting a hostage should deduct as many points as shooting a colleague. That makes sense.