### PR TITLE
Adjusted bonus rating

### DIFF
--- a/System/Leadership.ini
+++ b/System/Leadership.ini
@@ -96,7 +96,7 @@ IsNeverHidden=True
 Description=Suspects incapacitated
 TotalBonus=20
 ;the fraction of the per-enemy bonus received when an incapacitated enemy is arrested
-PerEnemyBonusFraction=0.65
+PerEnemyBonusFraction=0.75
 IsABonus=True
 IsNeverHidden=True
 
@@ -105,7 +105,7 @@ IsNeverHidden=True
 Description=Suspects neutralized
 TotalBonus=20
 ;the fraction of the per-enemy bonus received when an enemy is killed
-PerEnemyBonusFraction=0.2
+PerEnemyBonusFraction=0.5
 IsABonus=True
 IsNeverHidden=True
 


### PR DESCRIPTION
After much deliberation and some discussion I decided to make the evaluation a bit more fair and realistic.
**Suspects neutralized -> maximum 10 points**
**Suspects incapacitated -> maximum 15 points**
**Suspects arrested -> maximum 20 points**
This now also mathematically a bit more logical. The problem is that sometimes there is no way not to shoot especially with some custom maps and therefore the rating is unnecessarily negative. In reality you would not say that you are a bad SWAT officer. That's why I find this rating fairer.  Before it was about: 

**Suspects neutralized -> maximum 4 points approximately**
**Suspects incapacitated -> maximum 13 points approximately**
**Suspects arrested -> maximum 20 points**