### PR TITLE
 bCapFramerate config

### DIFF
--- a/System/Swat4X.ini
+++ b/System/Swat4X.ini
@@ -439,6 +439,7 @@ bVeryLowGore=False
 [Engine.LevelInfo]
 PhysicsDetailLevel=PDL_High
 AIRepositoryClassName=SwatAICommon.SwatAIRepository
+bCapFramerate=False
 
 [Engine.Console]
 ConsoleKey=192


### PR DESCRIPTION
bool bCapFramerate (globalconfig)
Frame rate is capped in net play if True, else the number of ServerMove updates is limited. 

This shoud boost FPS in MP accoring to many UT2003/4 tweak guides