### PR TITLE
reduce weapons clipping

### DIFF
--- a/System/SwatGame.ini
+++ b/System/SwatGame.ini
@@ -1,5 +1,5 @@
 [Engine.Hands]
-PlayerViewOffset=(X=-22,Y=7,Z=-12)
+PlayerViewOffset=(X=-18.5,Y=7,Z=-12)
 AnimationGroups=FP_Hand2.GrenadeHands
 AnimationGroups=FP_Hand2.MP5Hands
 AnimationGroups=FP_Hand2.1911Hands


### PR DESCRIPTION
that resolve 90% of the weapons clipping. 

could use also a x=-15 value but it ends with a little of fisheye effect on weapons.