### PR TITLE
FN FAL has wrong ammo

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -3234,14 +3234,13 @@ ZoomedAutoRecoilBase=320
 ;***************************
 [SwatEquipment.FNFALMG]
 ;; Ammo information
-PlayerAmmoOption=SwatAmmo.AK47MG_AP
-PlayerAmmoOption=SwatAmmo.AK47MG_FMJ
-PlayerAmmoOption=SwatAmmo.AK47MG_JSP
-PlayerAmmoOption=SwatAmmo.AK47MG_JHP
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_FMJ",Chance=65)
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_JHP",Chance=10)
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_LowAmmo_FMJ",Chance=10)
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_AP",Chance=15)
+PlayerAmmoOption=SwatAmmo.SCARMG_AP
+PlayerAmmoOption=SwatAmmo.SCARMG_FMJ
+PlayerAmmoOption=SwatAmmo.SCARMG_JSP
+PlayerAmmoOption=SwatAmmo.SCARMG_JHP
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.SCARMG_FMJ",Chance=75)
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.SCARMG_JHP",Chance=10)
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.SCARMG_AP",Chance=15)
 
 ;; Weight and Bulk
 Weight=4.3


### PR DESCRIPTION
FAL has NATO 7.62 , not Russian one. 
it can be replaced with SCAR-H ammo.