### PR TITLE
CS gas crash possible fix

### DIFF
--- a/Source/Game/SwatGame/Classes/AI/SwatOfficer.uc
+++ b/Source/Game/SwatGame/Classes/AI/SwatOfficer.uc
@@ -1216,6 +1216,10 @@ function ReactToCSGas(Actor GasContainer, float Duration, float SPPlayerProtecti
     Distance = VSize(Location - GasContainer.Location);
     DistanceEffect = (600 - Distance)/(600);
 
+    //added a minum distance effect to avoid effect crash 
+    if (DistanceEffect < 0.2 )
+	  DistanceEffect = 0.2; 
+	
     if ( HasProtection( 'IProtectFromCSGas' ) )
     {
         return;

--- a/Source/Game/SwatGame/Classes/SwatPlayer.uc
+++ b/Source/Game/SwatGame/Classes/SwatPlayer.uc
@@ -2581,6 +2581,10 @@ function ReactToCSGas( Actor GasContainer,
 	Distance = VSize(Location - GasContainer.Location);
 	DistanceEffect = (600 - Distance)/(600);
 
+	//added a minum distance effect to avoid effect crash 
+	if (DistanceEffect < 0.2 )
+	           DistanceEffect = 0.2; 
+
     if ( Level.NetMode == NM_Client )
         return;
 

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -6556,7 +6556,7 @@ ReactionDuration=22
 SPPlayerProtectiveEquipmentDurationScaleFactor=0.5
 MPPlayerProtectiveEquipmentDurationScaleFactor=0.5
 ; min and max radius of effect
-Radius=(Min=20.0,Max=600.0)
+Radius=(Min=20.0,Max=599.0)
 ; Time it takes the radius of effect to expand from min to max.
 ; You can watch the radius expand by typing "rend collision" before
 ; throwing the gas grenade.


### PR DESCRIPTION
i've found that effect duration code is probably passing negative or zero duration to time , causing effect to crash. 

https://github.com/eezstreet/SWATEliteForce/blob/52ff0e3158ff1842a5ea36e65e73ecfe79bd9aba/Source/Game/SwatGame/Classes/SwatPlayer.uc#L2535

Distance = VSize(Location - GasContainer.Location);
DistanceEffect = (600 - Distance)/(600);

(600-VSize) probably return a negative value, making the timer crash the effect. 
I've reduced the gas radius to 599 (could be leaved at 600 if you can pass 0 to timer) and added a minimum distance effect of 0.2 so we never pass a wrong value ever again and making the effect less "on/off" if around the border of the gas radius.