### PR TITLE
Improved times for toolkit: lockpicking and bomb defusing

### DIFF
--- a/System/SwatGame.ini
+++ b/System/SwatGame.ini
@@ -87,12 +87,12 @@ InteractDistance=140
 InteractDistance=768
 
 [SwatGame.BombBase]
-QualifyTimeForToolkit=10.0
+QualifyTimeForToolkit=12.0
 
 [SwatGame.SwatDoor]
-QualifyTimeForToolkit=20.0
+QualifyTimeForToolkit=8.0
 QualifyTimeForWedge=1.367
-QualifyTimeForC2Charge=3.0
+QualifyTimeForC2Charge=5.0
 Mass=100.000000
 OpenLeftAwayClosePointBoneName=OLAwayClose
 OpenLeftTowardsClosePointBoneName=OLTowardsClose


### PR DESCRIPTION
20 seconds for lockpicking renders the toolkit useless, and you have to take into account all the bulk that you are carrying, basically You can spend more than 40 seconds opening a door and i'm sure that a lot of people like to be stealthy. 8 seconds imo works better with bulk and it's still a reasonable time.

I've made another small changes to bomb defusal and C2 removal times.