### PR TITLE
Misc adjustments to shotguns

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -3896,17 +3896,17 @@ ThirdPersonModelClass=class'SwatEquipmentModels2.CAR_ThirdPerson'
 PlayerUsable=true
 
 ;; Ammo information
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.M870SGAmmo",Chance=60)
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.M870SG000Ammo",Chance=30)
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.M870SGSabotAmmo",Chance=10)
-MagazineSize=5
-PlayerAmmoOption=SwatAmmo.M870SGBreachingAmmo
-PlayerAmmoOption=SwatAmmo.M870SG4Ammo
-PlayerAmmoOption=SwatAmmo.M870SG1Ammo
-PlayerAmmoOption=SwatAmmo.M870SG0Ammo
-PlayerAmmoOption=SwatAmmo.M870SG000Ammo
-PlayerAmmoOption=SwatAmmo.M870SGSabotAmmo
-PlayerAmmoOption=SwatAmmo.M870SGAmmo
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4Super90SGAmmo",Chance=60)
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4Super90SG000Ammo",Chance=30)
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4Super90SGSabotAmmo",Chance=10)
+MagazineSize=8
+PlayerAmmoOption=SwatAmmo.M4Super90SGBreachingAmmo
+PlayerAmmoOption=SwatAmmo.M4Super90SG4Ammo
+PlayerAmmoOption=SwatAmmo.M4Super90SG1Ammo
+PlayerAmmoOption=SwatAmmo.M4Super90SG0Ammo
+PlayerAmmoOption=SwatAmmo.M4Super90SG000Ammo
+PlayerAmmoOption=SwatAmmo.M4Super90SGSabotAmmo
+PlayerAmmoOption=SwatAmmo.M4Super90SGAmmo
 
 ;; Weight and Bulk
 Weight=3.19
@@ -3935,7 +3935,6 @@ MuzzleVelocity=20387
 OverrideArmDamageModifier=1.0
 Range=4000
 UseAnimationRate=1.0
-Choke=1.36
 
 ;; Aiming information
 ; Aim error penalties
@@ -3976,7 +3975,7 @@ PlayerUsable=true
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4Super90SGAmmo",Chance=60)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4Super90SG000Ammo",Chance=30)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4Super90SGSabotAmmo",Chance=10)
-MagazineSize=7
+MagazineSize=8
 PlayerAmmoOption=SwatAmmo.M4Super90SGBreachingAmmo
 PlayerAmmoOption=SwatAmmo.M4Super90SG4Ammo
 PlayerAmmoOption=SwatAmmo.M4Super90SG1Ammo
@@ -4067,17 +4066,17 @@ IronSightRotationOffset=(Pitch=-120,Yaw=30,Roll=400)
 PlayerUsable=true
 
 ;; Ammo information
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.NovaPumpSGAmmo",Chance=60)
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.NovaPumpSG000Ammo",Chance=30)
-EnemyUsesAmmo=(AmmoClass="SwatAmmo.NovaPumpSGSabotAmmo",Chance=10)
-MagazineSize=7
-PlayerAmmoOption=SwatAmmo.NovaPumpSGBreachingAmmo
-PlayerAmmoOption=SwatAmmo.NovaPumpSG4Ammo
-PlayerAmmoOption=SwatAmmo.NovaPumpSG1Ammo
-PlayerAmmoOption=SwatAmmo.NovaPumpSG0Ammo
-PlayerAmmoOption=SwatAmmo.NovaPumpSG000Ammo
-PlayerAmmoOption=SwatAmmo.NovaPumpSGSabotAmmo
-PlayerAmmoOption=SwatAmmo.NovaPumpSGAmmo
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.M870SGAmmo",Chance=60)
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.M870SG000Ammo",Chance=30)
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.M870SGSabotAmmo",Chance=10)
+MagazineSize=5
+PlayerAmmoOption=SwatAmmo.M870SGBreachingAmmo
+PlayerAmmoOption=SwatAmmo.M870SG4Ammo
+PlayerAmmoOption=SwatAmmo.M870SG1Ammo
+PlayerAmmoOption=SwatAmmo.M870SG0Ammo
+PlayerAmmoOption=SwatAmmo.M870SG000Ammo
+PlayerAmmoOption=SwatAmmo.M870SGSabotAmmo
+PlayerAmmoOption=SwatAmmo.M870SGAmmo
 
 ;; Weight and Bulk
 Weight=3.89
@@ -4183,7 +4182,6 @@ MuzzleVelocity=20387
 Range=4000
 ReloadAnimationRate=1.0
 UseAnimationRate=1.75
-Choke=1.51
 
 ;; Aiming information
 ; Aim error penalties
@@ -4548,7 +4546,7 @@ ZoomedAutoRecoilBase=190
 PlayerUsable=true
 
 ;RoundBasedWeapon configuration
-MagazineSize=7
+MagazineSize=5
 ;FiredWeapon configuration
 PlayerAmmoOption=SwatAmmo.LessLethalAmmo
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.LessLethalAmmo",Chance=100)
@@ -4647,7 +4645,7 @@ MuzzleVelocity=20387
 Range=4000
 ReloadAnimationRate=1.0
 UseAnimationRate=1.75
-Choke=1.51
+Choke=0.85
 MagazineSize=5
 
 ;; Aiming information


### PR DESCRIPTION
Fixed magazine capacities:
M1 Super 90: 7+1 rounds not 4+1 (the model features a 7 round tube magazine.)
M4 Super 90: 7+1 not 6+1
Nova Tactical: 4+1 not 6+1 (the model features the standard 4 round tube magazine.)
Removed choke modifier on the M1, it didn't made sense since it has the same barrel lenght as the M4.
Tweaked choke modifier on Remington 870 (regular and less lethal) the model is depicted with a 18 inch barrel.