### PR TITLE
Weight/Bulk check fix in MP panel

### DIFF
--- a/Source/Game/SwatGui/Classes/SwatMPPage.uc
+++ b/Source/Game/SwatGui/Classes/SwatMPPage.uc
@@ -449,7 +449,6 @@ function CommonOnClick(GUIComponent Sender)
                 bPressedReady = true;
                 MyStartButton.SetCaption(UnreadyString);
               }
-	       MyMPLoadoutPanel.Deactivate();
             } else {
               SwatGuiController(Controller).SetPlayerNotReady();
               bPressedReady = false;

--- a/Source/Game/SwatGui/Classes/SwatMPPage.uc
+++ b/Source/Game/SwatGui/Classes/SwatMPPage.uc
@@ -443,11 +443,13 @@ function CommonOnClick(GUIComponent Sender)
 	{
 		case MyStartButton:
             if(!bPressedReady) {
+		MyMPLoadoutPanel.Activate();
               if(MyMPLoadoutPanel.CheckWeightBulkValidity()) {
                 SwatGuiController(Controller).SetPlayerReady();
                 bPressedReady = true;
                 MyStartButton.SetCaption(UnreadyString);
               }
+	       MyMPLoadoutPanel.Deactivate();
             } else {
               SwatGuiController(Controller).SetPlayerNotReady();
               bPressedReady = false;


### PR DESCRIPTION
Weight/Bulk is only checked when panel is activated .... 
As it is now it only works when in loadout panel and player can be ready "over the limits" by just be in another panel. 

The same happens if "vote starting" but that need a more complex solution.