### PR TITLE
Fix non-lethal nova ironsight misalignment

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -4599,8 +4599,8 @@ FlashlightRotation_1stPerson=(Pitch=0,Yaw=0,Roll=0)
 FlashlightPosition_3rdPerson=(X=0,Y=-39.4,Z=1.15)
 FlashlightRotation_3rdPerson=(Pitch=0,Yaw=-16384,Roll=0)
 LightstickThrowAnimPostfix="SG"
-IronSightLocationOffset=(X=2,Y=-8,Z=1.9)
-IronSightRotationOffset=(Pitch=425,Yaw=25,Roll=1200)
+IronSightLocationOffset=(X=2,Y=-7.86,Z=2.125)
+IronSightRotationOffset=(Pitch=400,Yaw=32,Roll=1200)
 
 Weight=3.89
 Bulk=21.516


### PR DESCRIPTION
- Use its lethal counterpart (Nova Tactical) ironsight position and rotation values.

Fix #628