### PR TITLE
Fix wrong variant for supressed mp5ka4 guns gui

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -1657,7 +1657,7 @@ SelectableVariants=(VariantName="Suppressor",VariantClass=class'SwatEquipment.Si
 [SwatEquipment.SilencedMP5KSMG]
 PlayerUsable=true
 bIsVariant=true
-OriginalVariant=class'SwatEquipment.MP5KtSMG'
+OriginalVariant=class'SwatEquipment.MP5KSMG'
 
 ;; Ammo information
 PlayerAmmoOption=SwatAmmo.MP5SDSMG_AP
@@ -1734,7 +1734,7 @@ ZoomedAutoRecoilBase=160
 ;*****************************
 [SwatEquipment.SilencedMP5KtSMG]
 bIsVariant=true
-OriginalVariant=class'SwatEquipment.MP5KSMG'
+OriginalVariant=class'SwatEquipment.MP5KtSMG'
 
 ;; Weight and Bulk
 Weight=2.3


### PR DESCRIPTION
-  Flip between mp5ka4 supressed machine pistol
and submachine gun, correctly.

- Also minor note, it's probably a better idea to rename these variants precisely
without abbreviation to avoid similar error happening in the future.

Fix #626 