### PR TITLE
Fix kilogram to pound unit conversion formula

### DIFF
--- a/Source/Game/SwatGame/Classes/HUD/GUIWeight.uc
+++ b/Source/Game/SwatGame/Classes/HUD/GUIWeight.uc
@@ -13,6 +13,6 @@ private function string WeightStringText(float Weight) {
 	}
   	else
   	{
-  		return "" $ (Weight * 0.453592) $ " lb";
+  		return "" $ (Weight / 0.453592) $ " lb";
   	}
 }

--- a/Source/Game/SwatGui/Classes/SwatLoadoutPanel.uc
+++ b/Source/Game/SwatGui/Classes/SwatLoadoutPanel.uc
@@ -367,7 +367,7 @@ function UpdateWeights() {
   }
   else if(SwatGUIControllerBase(Controller).IsUsingImperialMeasurements())
   {
-    MyEquipmentWeightLabel.Caption = ""$(MyCurrentLoadOut.GetTotalWeight() * 0.453592)$" lb";
+    MyEquipmentWeightLabel.Caption = ""$(MyCurrentLoadOut.GetTotalWeight() / 0.453592)$" lb";
   }
   
   MyEquipmentBulkLabel.Caption =""$bulkDisplay$"%";


### PR DESCRIPTION
- The existing conversion was slightly incorrect because it was for
pound to kilogram conversion (multiplication instead of division) and
not for the other way around.

- Another side note as future reference, there's also another different
alternative, i,e from kilogram to pound: kg * 2.205 (or 2.204)

Fix #503 