### PR TITLE
Beanbag no longer applies Stung action in most cases.

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/CommanderAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/CommanderAction.uc
@@ -1136,7 +1136,10 @@ function NotifyStung(Actor Grenade, vector StungGrenadeLocation, float StunnedDu
 		}
 	}
 
-	if (CurrentStungGoal == None)
+	// We don't apply the "Stung" goal if this was a beanbag shot and we are already playing
+	// the "React to Being Shot" goal. Prevents wacky double-reaction animation, and looks/feels
+	// so much more realistic. Beanbag is no longer a god-tier weapon.
+	if (CurrentStungGoal == None && (Grenade != None || CurrentReactToBeingShotGoal == None))
 	{
 		CurrentStungGoal = new class'StungGoal'(characterResource(), Grenade, StungGrenadeLocation, StunnedDuration);
 		assert(CurrentStungGoal != None);

--- a/Source/Game/SwatAICommon/Classes/Actions/CommanderAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/CommanderAction.uc
@@ -1118,7 +1118,10 @@ function NotifyStunnedByC2Detonation(vector C2ChargeLocation, float StunnedDurat
 }
 
 // if grenade is none, then we got hit by the bean bag
-function NotifyStung(Actor Grenade, vector StungGrenadeLocation, float StunnedDuration)
+// Returns `true` if the Stung Goal was applied (or an existing Strung Action was updated),
+// returns `false` if the Stung Goal was not applied (because this AI was hit with a beanbag
+// and is already playing the "React to Being Shot" goal)
+function bool NotifyStung(Actor Grenade, vector StungGrenadeLocation, float StunnedDuration)
 {
 	// create the reaction behavior
 	if (CurrentStungGoal != None)
@@ -1133,12 +1136,13 @@ function NotifyStung(Actor Grenade, vector StungGrenadeLocation, float StunnedDu
 		{
 			assert(StungAction(CurrentStungGoal.achievingAction) != None);
 			StungAction(CurrentStungGoal.achievingAction).ExtendBeingStunned(StunnedDuration);
+			return true;
 		}
 	}
 
 	// We don't apply the "Stung" goal if this was a beanbag shot and we are already playing
 	// the "React to Being Shot" goal. Prevents wacky double-reaction animation, and looks/feels
-	// so much more realistic. Beanbag is no longer a god-tier weapon.
+	// so much more realistic. Beanbag is no longer a god-tier weapon. - K.F. 2025
 	if (CurrentStungGoal == None && (Grenade != None || CurrentReactToBeingShotGoal == None))
 	{
 		CurrentStungGoal = new class'StungGoal'(characterResource(), Grenade, StungGrenadeLocation, StunnedDuration);
@@ -1147,7 +1151,12 @@ function NotifyStung(Actor Grenade, vector StungGrenadeLocation, float StunnedDu
 
         CurrentStungGoal.bShouldRunFromStunningDevice = ShouldRunWhenStung();
 		CurrentStungGoal.postGoal(self);
+		return true;
 	}
+
+	// We didn't actually apply the StungGoal, because we were hit with a beanbag and
+	// already have a ReactToBeingShotGoal. -K.F. 2025
+	return false;
 }
 
 // subclasses should override

--- a/Source/Game/SwatGame/Classes/AI/SwatAICharacter.uc
+++ b/Source/Game/SwatGame/Classes/AI/SwatAICharacter.uc
@@ -709,10 +709,33 @@ private function bool CantBeDazed()
 
 private function ApplyDazedEffect(SwatProjectile Grenade, Vector SourceLocation, float AIStingDuration)
 {
+    local CommanderAction commanderAction;
+    local bool stungApplied;
+
+    commanderAction = GetCommanderAction();
+
 	LastTimeStung = Level.TimeSeconds;
 	StungDuration = AIStingDuration;
 
-	GetCommanderAction().NotifyStung(Grenade, SourceLocation, StungDuration);
+	stungApplied = GetCommanderAction().NotifyStung(Grenade, SourceLocation, StungDuration);
+
+    // Fix for a bug caused by my change to NotifyStung (which makes it so that the
+    // Stung Goal is not applied if we are already playing the "React to Being Shot"
+    // Goal). The bug caused compliant suspects to play the wrong upper body animation
+    // when they look at a nearby officer as part of the "Look At Officers" action;
+    // the suspect would play an "aim weapon at" animation as if they were still armed.
+
+    // If StungDuration is greater than 0 at the end of this function, IsStung() will
+    // return true until the StungDuration has passed. There's no explanation for this
+    // in the UC scripts, so maybe it has something to do with native code.
+
+    // Anyway, if IsStung() returns true, the animation kAnimationSetCompliantLookAt
+    // doesn't get loaded, which causes the bug described above. Setting the
+    // StungDuration to 0 here fixes the bug. -K.F. 2025
+    if (!stungApplied)
+    {
+        StungDuration = 0.0;
+    }
 }
 
 private function DirectHitByGrenade(Pawn Instigator, float Damage, float AIStingDuration, class<DamageType> DamageType)


### PR DESCRIPTION
Originally, when we hit someone with the beanbag, they'd play the `ReactToBeingShot` action and _then_ the `Stung` action. This looked janky (two different reaction animations playing back to back), had a big impact on morale, and often stunned the target for a very long time.

This PR changes the beanbag behavior, so if the target is already playing the `ReactToBeingShot` action, they do not also play the `Stung` action. This looks much better (no janky double-reaction), and plays much better (beanbag shotgun is no longer OP, and feels much more realistic).