### PR TITLE
Iron Sight alignment fixes

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -469,8 +469,8 @@ Bulk=2.5668
 GUIImage=material'gui_tex.equip_9mmpistol'
 WeaponCategory=WeaponClass_Pistol
 AllowedSlots=WeaponEquip_Either
-IronSightLocationOffset=(X=3,Y=-7.6,Z=3.3)
-IronSightRotationOffset=(Pitch=540,Yaw=-50,Roll=800)
+IronSightLocationOffset=(X=3,Y=-7.7,Z=3.25)
+IronSightRotationOffset=(Pitch=540,Yaw=-37,Roll=800)
 
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.NineMMpistol_FirstPerson'
@@ -551,8 +551,8 @@ GUIImage=material'gui_sas.glock17'
 FirstPersonModelClass=class'SwatEquipmentModels2.Glock19_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.Glock19_ThirdPerson'
 
-IronSightLocationOffset=(X=3,Y=-7.68,Z=3)
-IronSightRotationOffset=(Pitch=540,Yaw=0,Roll=700)
+IronSightLocationOffset=(X=3,Y=-7.72,Z=3.23)
+IronSightRotationOffset=(Pitch=500,Yaw=-30,Roll=800)
 
 ;; Aiming information
 ; Aim error penalties
@@ -917,8 +917,8 @@ Bulk=2.744
 FirstPersonModelClass=class'SwatEquipmentModels2.p226_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.p226_ThirdPerson'
 UnequipAnimationRate=1.5
-IronSightLocationOffset=(X=1.5,Y=-7.9,Z=3)
-IronSightRotationOffset=(Pitch=600,Yaw=0,Roll=800)
+IronSightLocationOffset=(X=1.5,Y=-7.86,Z=3.13)
+IronSightRotationOffset=(Pitch=550,Yaw=-30,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -1004,8 +1004,8 @@ Bulk=4.004
 FirstPersonModelClass=class'SwatEquipmentModels2.p226sd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.p226sd_ThirdPerson'
 UnequipAnimationRate=1.5
-IronSightLocationOffset=(X=1.5,Y=-7.9,Z=3)
-IronSightRotationOffset=(Pitch=600,Yaw=0,Roll=800)
+IronSightLocationOffset=(X=1.5,Y=-7.86,Z=3.13)
+IronSightRotationOffset=(Pitch=550,Yaw=-30,Roll=800)
 
 ;; Flashlight
 HasAttachedFlashlight=true
@@ -2164,8 +2164,8 @@ Bulk=22.464
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels3.ColtSMG_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels3.ColtSMG_ThirdPerson'
-IronSightLocationOffset=(X=2,Y=-6.90,Z=3.9)
-IronSightRotationOffset=(Pitch=-175,Yaw=77,Roll=0)
+IronSightLocationOffset=(X=2,Y=-6.94,Z=4.3)
+IronSightRotationOffset=(Pitch=-325,Yaw=90,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_tex3.Equip_ColtSMG'
@@ -3177,7 +3177,8 @@ Bulk=19.8
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.AK74su_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.AK74su_ThirdPerson'
-IronSightLocationOffset=(X=0.5,Y=-5.740,Z=5.2)
+IronSightLocationOffset=(X=2,Y=-5.84,Z=4.91)
+IronSightRotationOffset=(Pitch=250,Yaw=50,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_tex3.equip_AKs74u'


### PR DESCRIPTION
Fix iron sight alignment for Colt Model 635, AKS-74U, Glock 17, Glock 19, Sig P226, Sig P226-SD