### PR TITLE
Hands.uc: much better animation between hip-fire and ADS pose; better smoothing.

### DIFF
--- a/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
@@ -197,7 +197,7 @@ var config float MaxInertiaOffset;
 
 //a bit of a hack since we can't add vars to Hands.uc - K.F.
 var float IronSightAnimationProgress;	//denotes position of weapon, in linear range where 0 = held at hip and 1 = fully aiming down sight
-var array<vector> AnimationSplinePoints;
+var vector HandsOffsetLastFrame;
 
 var bool bPenetratesDoors;
 
@@ -1379,18 +1379,13 @@ simulated function SetIronSightAnimationProgress(float value)
 	IronSightAnimationProgress = value;
 }
 
-simulated function array<vector> GetAnimationSplinePoints()
+simulated function vector GetHandsOffsetLastFrame()
 {
-	return AnimationSplinePoints;
+  return HandsOffsetLastFrame;
 }
-simulated function AddAnimationSplinePoint(vector value)
-{
-	AnimationSplinePoints.Insert(AnimationSplinePoints.Length, 1);
-	AnimationSplinePoints[AnimationSplinePoints.Length - 1] = value;
-	if (AnimationSplinePoints.Length > 4)
-	{
-		AnimationSplinePoints.Remove(0, 1);
-	}
+
+simulated function SetHandsOffsetLastFrame(vector value) {
+  HandsOffsetLastFrame = value;
 }
 
 simulated function float GetBaseAimError()

--- a/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/HandheldEquipment.uc
@@ -1423,13 +1423,13 @@ simulated function float GetIronSightAnimationProgress()
 }
 simulated function SetIronSightAnimationProgress(float value) { }
 
-simulated function array<vector> GetAnimationSplinePoints()
+simulated function vector GetHandsOffsetLastFrame()
 {
-	local array<vector> AnimationSplinePoints;
+	local vector Offset;
 
-	return AnimationSplinePoints;
+	return Offset;
 }
-simulated function AddAnimationSplinePoint(vector value) { }
+simulated function SetHandsOffsetLastFrame(vector value) { }
 
 event Destroyed()
 {

--- a/Source/Unreal/Engine/Classes/Equipment/Hands.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Hands.uc
@@ -170,10 +170,19 @@ simulated function UpdateHandsForRendering()
     {
         NewLocation = (Location * ViewInertia) + (TargetLocation * (1 - ViewInertia));
 
+        // Apply inertia (reducing weapon's movement speed).
         if (ViewInertia > 0) {
             Change = NewLocation - Location;
-            Change *= (deltaTime / 0.016667);
+            // Scale for framerate. We interp halfway back to 1 because this gives more consistent results
+            // across different framerates.
+            Change *= 0.5 + (deltaTime / 0.016667) * 0.5;
             NewLocation = Location + Change;
+        }
+
+        // Smoothing.
+        if (ViewInertia > 0) {
+            NewLocation = (NewLocation + (TargetLocation - EquippedItem.GetHandsOffsetLastFrame())) / 2.0;
+            EquippedItem.SetHandsOffsetLastFrame(TargetLocation - NewLocation);
         }
 
         // Cap the maximum distance we can be away from the target location.


### PR DESCRIPTION
Previously we interpolated between the default (hip-fire) and ADS pose using a poorly written non-linear algorithm (my fault). For weapons which had their hip-fire pose modified via INI (e.g. the P90), this could cause the weapon to briefly become wildly displaced (either towards or away from the center of the screen) when starting to animate between the two poses.

This PR switches to a simple linear interpolation between the two poses, which looks correct regardless of the hip-fire and ADS poses. The code is also cleaner, simpler, and easier to understand.