### PR TITLE
Add Ingram MAC-10/MAC-10 SD playable weapons

### DIFF
--- a/Source/Game/SwatEquipment/Classes/Weapons/MAC10SMG.uc
+++ b/Source/Game/SwatEquipment/Classes/Weapons/MAC10SMG.uc
@@ -1,0 +1,1 @@
+class MAC10SMG extends SubMachineGun config(SwatEquipment);

--- a/Source/Game/SwatEquipment/Classes/Weapons/MAC10sdSMG.uc
+++ b/Source/Game/SwatEquipment/Classes/Weapons/MAC10sdSMG.uc
@@ -1,0 +1,1 @@
+class MAC10sdSMG extends MAC10SMG config(SwatEquipment);

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -2285,6 +2285,142 @@ ZoomedSemiRecoilBase=209
 ZoomedBurstRecoilBase=209
 ZoomedAutoRecoilBase=180
 
+;***********************
+;  MAC-10
+;***********************
+[SwatEquipment.MAC10SMG]
+PlayerUsable=true
+
+;; Ammo information
+PlayerAmmoOption=SwatAmmo.IngramHG_FMJ
+EnemyUsesAmmo=(AmmoClass="SwatAmmo.IngramHG_FMJ",Chance=100)
+
+;; Animation settings
+AimAnimation=WeaponAnimAim_Handgun
+LowReadyAnimation=WeaponAnimLowReady_Handgun
+IdleWeaponCategory=IdleWithHandgun
+
+;; Weight and Bulk
+Weight=2.84
+Bulk=7.73
+
+;; Viewmodel and Zoom
+FirstPersonModelClass=class'SwatEquipmentModels2.MAC10_FirstPerson'
+ThirdPersonModelClass=class'SwatEquipmentModels2.MAC10_ThirdPerson'
+DefaultLocationOffset=(X=13,Y=0,Z=2)
+DefaultRotationOffset=(Pitch=0,Yaw=0,Roll=0)
+IronSightLocationOffset=(X=14,Y=-6.22,Z=4.05)
+IronSightRotationOffset=(Pitch=15,Yaw=30,Roll=200)
+
+;; Flashlight
+HasAttachedFlashlight=false
+
+;; GUI
+GUIImage=material'gui_tex3.equip_MAC10'
+WeaponCategory=WeaponClass_MachinePistol
+AllowedSlots=WeaponEquip_Either
+
+;; Firing
+BurstRateFactor=3.25
+MuzzleVelocity=14683
+Range=4000
+UseAnimationRate=1.00
+AvailableFireMode=FireMode_Auto
+AvailableFireMode=FireMode_Single
+
+;; Aiming information
+; Aim error penalties
+EquippedAimErrorPenalty=7
+FiredAimErrorPenalty=2.3
+InjuredAimErrorPenalty=0.5
+LookAimErrorPenaltyFactor=0.000125
+MaxInjuredAimErrorPenalty=3
+MaxLookAimErrorPenalty=6
+StandToWalkAimErrorPenalty=2.25
+WalkToRunAimErrorPenalty=15
+
+; Aim error modifiers
+CrouchingAimError=0.8
+MaxAimError=40.0
+RunningAimError=2.55
+StandingAimError=0.9
+WalkingAimError=1.6
+
+; Aim error recovery rates
+AimErrorBreakingPoint=2
+LargeAimErrorRecoveryRate=21.5
+SmallAimErrorRecoveryRate=5.25
+
+;; Recoil
+AutoRecoilPerShot=62
+RecoilBackDuration=0.025
+RecoilForeDuration=0.35
+SemiRecoilBase=235
+AutoRecoilBase=220
+ZoomedAutoRecoilPerShot=62
+ZoomedSemiRecoilBase=235
+ZoomedAutoRecoilBase=220
+
+NoVariantName="No Attachments"
+SelectableVariants=(VariantName="Suppressor",VariantClass=class'SwatEquipment.MAC10sdSMG')
+
+;***********************
+;  MAC-10 SD
+;***********************
+[SwatEquipment.MAC10sdSMG]
+bIsVariant=true
+OriginalVariant=class'SwatEquipment.MAC10SMG'
+
+MagazineSize=30
+
+;; Weight and Bulk
+Weight=3.38
+Bulk=14.28
+
+;; Viewmodel and Zoom
+FirstPersonModelClass=class'SwatEquipmentModels2.MAC10SD_FirstPerson'
+ThirdPersonModelClass=class'SwatEquipmentModels2.MAC10SD_ThirdPerson'
+
+;; GUI
+GUIImage=material'gui_tex3.equip_MAC10SD'
+
+;; Firing
+BurstRateFactor=2
+MuzzleVelocity=14300
+
+;; Aiming information
+; Aim error penalties
+EquippedAimErrorPenalty=6
+FiredAimErrorPenalty=2.0
+InjuredAimErrorPenalty=0.4
+LookAimErrorPenaltyFactor=0.000125
+MaxInjuredAimErrorPenalty=2.75
+MaxLookAimErrorPenalty=5.25
+StandToWalkAimErrorPenalty=2.5
+WalkToRunAimErrorPenalty=16
+
+; Aim error modifiers
+CrouchingAimError=0.75
+MaxAimError=35.0
+RunningAimError=2.65
+StandingAimError=0.8
+WalkingAimError=1.65
+
+; Aim error recovery rates
+AimErrorBreakingPoint=2
+LargeAimErrorRecoveryRate=22.5
+SmallAimErrorRecoveryRate=5.0
+
+;; Recoil
+AutoRecoilPerShot=50
+RecoilBackDuration=0.022
+RecoilForeDuration=0.30
+SemiRecoilBase=215
+AutoRecoilBase=205
+ZoomedAutoRecoilPerShot=50
+ZoomedSemiRecoilBase=215
+ZoomedAutoRecoilBase=205
+
 ;*************************
 ;
 ;  ASSAULT AND BATTLE RIFLES
@@ -6898,6 +7034,16 @@ Validity=NETVALID_MPOnly
 TeamValidity=TEAMVALID_SuspectsOnly
 bSelectable=1
 
+EquipmentClassName=SwatEquipment.MAC10SMG
+Validity=NETVALID_MPOnly
+TeamValidity=TEAMVALID_SuspectsOnly
+bSelectable=1
+
+EquipmentClassName=SwatEquipment.MAC10sdSMG
+Validity=NETVALID_MPOnly
+TeamValidity=TEAMVALID_SuspectsOnly
+bSelectable=1
+
 EquipmentClassName=SwatEquipment.FNP90SMG
 Validity=NETVALID_All
 TeamValidity=TEAMVALID_SWATOnly
@@ -7352,6 +7498,16 @@ TeamValidity=TEAMVALID_All
 bSelectable=1
 
 EquipmentClassName=SwatEquipment.UzitSMG
+Validity=NETVALID_MPOnly
+TeamValidity=TEAMVALID_SuspectsOnly
+bSelectable=1
+
+EquipmentClassName=SwatEquipment.MAC10SMG
+Validity=NETVALID_MPOnly
+TeamValidity=TEAMVALID_SuspectsOnly
+bSelectable=1
+
+EquipmentClassName=SwatEquipment.MAC10sdSMG
 Validity=NETVALID_MPOnly
 TeamValidity=TEAMVALID_SuspectsOnly
 bSelectable=1
@@ -7877,6 +8033,10 @@ EquipmentClassName=SwatAmmo.PythonRevolverHG_AP
 Validity=NETVALID_All
 TeamValidity=TEAMVALID_All
 bSelectable=1
+EquipmentClassName=SwatAmmo.IngramHG_FMJ
+Validity=NETVALID_All
+TeamValidity=TEAMVALID_All
+bSelectable=1
 EquipmentClassName=SwatAmmo2.StingrayAmmo
 Validity=NETVALID_All
 TeamValidity=TEAMVALID_All
@@ -8075,6 +8235,10 @@ Validity=NETVALID_All
 TeamValidity=TEAMVALID_All
 bSelectable=1
 EquipmentClassName=SwatAmmo.PythonRevolverHG_AP
+Validity=NETVALID_All
+TeamValidity=TEAMVALID_All
+bSelectable=1
+EquipmentClassName=SwatAmmo.IngramHG_FMJ
 Validity=NETVALID_All
 TeamValidity=TEAMVALID_All
 bSelectable=1

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -2371,7 +2371,10 @@ SelectableVariants=(VariantName="Suppressor",VariantClass=class'SwatEquipment.MA
 bIsVariant=true
 OriginalVariant=class'SwatEquipment.MAC10SMG'
 
-MagazineSize=30
+;; Animation settings
+AimAnimation=WeaponAnimAim_SubmachineGun
+LowReadyAnimation=WeaponAnimLowReady_SubmachineGun
+IdleWeaponCategory=IdleWithSubmachineGun
 
 ;; Weight and Bulk
 Weight=3.38

--- a/System/SwatEquipment.int
+++ b/System/SwatEquipment.int
@@ -614,6 +614,32 @@ RateOfFire=600 RPM
 [UziTSMG]
 Description=The Uzi is a compact and reliable sub-machinegun that was developed in the early fifties in Israel. It's a staple of many Hollywood gang movies.  It has a slow rate of fire and is very easy to control even when fired on full auto.  This model is equipped with a suppressor making it a more stealthy choice. Despite not being a weapon used by SWAT, this weapon has been given a flashlight for more tactical use in dark environments.
 
+[MAC10SMG]
+Description=The Military Armament Corporation Model 10, better known as the "MAC-10", is compact machine pistol with a high rate of fire. This version is chambered in .45 ACP. Sometimes described as a "bullet hose", the MAC-10 was built for concealability, not for accuracy. The iron sights are not adjustable, and recoil is considerable.
+FriendlyName=MAC-10
+ShortName=MAC-10
+Manufacturer=Military Armament Corporation (MAC)
+Caliber=.45 ACP
+CountryOfOrigin=United States
+ProductionStart=1964
+FireModes=Semi-Automatic, Full-Auto
+MagazineSizeString=30
+TotalAmmoString=10 magazines
+RateOfFire=1145 RPM
+
+[MAC10sdSMG]
+Description=The Military Armament Corporation Model 10, better known as the "MAC-10", is compact machine pistol with a high rate of fire. This version is chambered in .45 ACP. Sometimes described as a "bullet hose", the MAC-10 was built for concealability, not for accuracy. This variant includes a large suppressor, which makes the weapon somewhat more controllable but doubles its length.
+FriendlyName=MAC-10 Suppressed
+ShortName=MAC-10 SD
+Manufacturer=Military Armament Corporation (MAC)
+Caliber=.45 ACP
+CountryOfOrigin=United States
+ProductionStart=1964
+FireModes=Semi-Automatic, Full-Auto
+MagazineSizeString=30
+TotalAmmoString=10 magazines
+RateOfFire=1145 RPM
+
 [SAWMG]
 Description=This light machine gun is intended only for military operations; however as with most weapons some are available on the black market. The weapon is designed to be fired accurately from the hip or shoulder, though it is more commonly fired from a deployed bipod. It uses a box magazine holding 200 rounds of disintegrating-link ammunition.
 FriendlyName=M249 Light Machine Gun

--- a/System/VisualEffects.ini
+++ b/System/VisualEffects.ini
@@ -1192,7 +1192,7 @@ Specification=(SpecificationType=Ingram3rdPersonMuzzleFlash,SpecificationClass=C
 
 [MAC10_ThirdPersonBurstFired]
 Event=BurstFired
-SourceClassName=Ingram_ThirdPerson
+SourceClassName=MAC10_ThirdPerson
 Chance=100
 Specification=(SpecificationType=Ingram3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
 
@@ -1210,13 +1210,13 @@ Specification=(SpecificationType=SilencedUzi1stPersonMuzzleFlash,SpecificationCl
 
 [MAC10SD_ThirdPersonFired]
 Event=Fired
-SourceClassName=MAC10_ThirdPerson
+SourceClassName=MAC10SD_ThirdPerson
 Chance=100
 Specification=(SpecificationType=Uzi3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
 
 [MAC10SD_ThirdPersonBurstFired]
 Event=BurstFired
-SourceClassName=Ingram_ThirdPerson
+SourceClassName=MAC10SD_ThirdPerson
 Chance=100
 Specification=(SpecificationType=Uzi3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
 

--- a/System/VisualEffects.ini
+++ b/System/VisualEffects.ini
@@ -64,6 +64,16 @@ EventResponse=M4A1CQBsdHolo_ThirdPersonFired
 EventResponse=M4A1CQBsdHolo_FirstPersonBurstFired
 EventResponse=M4A1CQBsdHolo_ThirdPersonBurstFired
 ; v7.1 end
+; v7.2
+EventResponse=MAC10_FirstPersonFired
+EventResponse=MAC10_FirstPersonBurstFired
+EventResponse=MAC10_ThirdPersonFired
+EventResponse=MAC10_ThirdPersonBurstFired
+EventResponse=MAC10SD_FirstPersonFired
+EventResponse=MAC10SD_FirstPersonBurstFired
+EventResponse=MAC10SD_ThirdPersonFired
+EventResponse=MAC10SD_ThirdPersonBurstFired
+; v7.2 end
 EventResponse=AK74su_ThirdPersonFired
 EventResponse=AK74su_FirstPersonFired
 EventResponse=M4A1_ThirdPersonFired
@@ -1159,6 +1169,58 @@ Chance=100
 Specification=(SpecificationType=Uzi3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
 
 ;;;;;;; v7.1 end
+
+;;;;;;;;; v7.2 add
+
+[MAC10_FirstPersonFired]
+Event=Fired
+SourceClassName=MAC10_FirstPerson
+Chance=100
+Specification=(SpecificationType=MAC10FirstPersonFired,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+[MAC10_FirstPersonBurstFired]
+Event=BurstFired
+SourceClassName=MAC10_FirstPerson
+Chance=100
+Specification=(SpecificationType=MAC10FirstPersonFired,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+[MAC10_ThirdPersonFired]
+Event=Fired
+SourceClassName=MAC10_ThirdPerson
+Chance=100
+Specification=(SpecificationType=Ingram3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+[MAC10_ThirdPersonBurstFired]
+Event=BurstFired
+SourceClassName=Ingram_ThirdPerson
+Chance=100
+Specification=(SpecificationType=Ingram3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+[MAC10SD_FirstPersonFired]
+Event=Fired
+SourceClassName=MAC10SD_FirstPerson
+Chance=100
+Specification=(SpecificationType=SilencedUzi1stPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+[MAC10SD_FirstPersonBurstFired]
+Event=BurstFired
+SourceClassName=MAC10SD_FirstPerson
+Chance=100
+Specification=(SpecificationType=SilencedUzi1stPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+[MAC10SD_ThirdPersonFired]
+Event=Fired
+SourceClassName=MAC10_ThirdPerson
+Chance=100
+Specification=(SpecificationType=Uzi3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+[MAC10SD_ThirdPersonBurstFired]
+Event=BurstFired
+SourceClassName=Ingram_ThirdPerson
+Chance=100
+Specification=(SpecificationType=Uzi3rdPersonMuzzleFlash,SpecificationClass=Class'IGVisualEffectsSubsystem.VisualEffectSpecification')
+
+;;;;;;; v7.2 end
 
 [AK74su_ThirdPersonFired]
 Event=Fired
@@ -7115,5 +7177,13 @@ EffectClass=class'SWATeffects2.TEC9_3rdPersonMuzzleFlash'
 ClassName=Class'IGVisualEffectsSubsystem.VisualEffectSpecification'
 Precache=True
 AttachToSource=True
+MaterialType=MVT_Default
+EffectClass=class'SWATeffects2.TEC9_1stPersonMuzzleFlash'
+
+[MAC10FirstPersonFired]
+ClassName=Class'IGVisualEffectsSubsystem.VisualEffectSpecification'
+Precache=True
+AttachToSource=True
+LocationOffset=(X=-8,Y=0,Z=1)
 MaterialType=MVT_Default
 EffectClass=class'SWATeffects2.TEC9_1stPersonMuzzleFlash'


### PR DESCRIPTION
Add Ingram MAC-10 .45 ACP machine pistol, and a suppressed (SD) variant:
- All-new first-person models and textures.
- All-new third-person models and textures.
- New first-person animations (heavily modified from vanilla Uzi animations)
- New inventory icons.
- Custom firing sound effects (mixed from other weapon sound effects)

Meshes and textures by Kevin Foley (me), 2025

**Note: This PR includes only the INI settings and stub scripts**; binary assets will be sent privately.

![equip_MAC10](https://github.com/user-attachments/assets/66b3e37a-33e3-4429-ae0a-18906ed01b86)
![equip_MAC10SD](https://github.com/user-attachments/assets/ffb7e90c-e83e-4774-8827-c12b9cd9ae75)

![MAC-10 Final](https://github.com/user-attachments/assets/7c556ce2-654a-446c-bede-1cd62aa7c372)
![MAC-10 SD Final](https://github.com/user-attachments/assets/d61851f9-070f-436c-8442-2ccaeb74e2a9)
![MAC-10 SD Reload](https://github.com/user-attachments/assets/0b1b1061-110e-44f0-b9f9-4e2ca42690bb)

Reload animations (MP4 recordings):

https://github.com/user-attachments/assets/1aa6d18a-2dbf-4740-b711-cddb316aa114

https://github.com/user-attachments/assets/51e53cab-9c55-48cd-8d99-8b2ee49ca716


