### PR TITLE
Add parallax effect for Aimpoint sight

### DIFF
--- a/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/Bases/SwatWeapon.uc
@@ -128,7 +128,7 @@ var() config bool bAlterThirdPersonMesh;
 var() config Mesh ThirdPersonMesh;
 var() config StaticMesh ThirdPersonStaticMesh;
 var() config array<Material> TPSkins; // Replacement skins for third-person mesh
-
+var() config bool bUsesRedDotSight; // If true, we'll enable the special reticle for this weapon. TODO: may eventually want an enum if we have other types of reflex sights.
 
 var(Firing) config int MagazineSize;
 var(Firing) protected config float Choke "Mostly used for shotguns - specifies how spread apart bullets should be - applied after AimError";
@@ -336,6 +336,10 @@ simulated function float GetDc1()
 simulated function float GetDc2()
 {
   return Dc2;
+}
+
+simulated function bool GetUsesRedDotSight() {
+  return bUsesRedDotSight;
 }
 
 simulated function bool ShouldHideCrosshairsInIronsights()

--- a/Source/Unreal/Engine/Classes/Equipment/RedDot.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/RedDot.uc
@@ -1,0 +1,16 @@
+// Used by Aimpoint sights.
+class RedDot extends Effects;
+
+defaultproperties
+{
+     DrawType=DT_Sprite
+     Texture=Texture'Sight_Reticles.Red_Dot_Reticle'
+     Physics=PHYS_None
+     bUnlit=True
+	 bNetTemporary=true
+	 bGameRelevant=true
+	 CollisionRadius=+0.00000
+	 CollisionHeight=+0.00000
+     RemoteRole=ROLE_None
+     bNetInitialRotation=true
+}

--- a/Source/Unreal/Engine/Classes/HUD.uc
+++ b/Source/Unreal/Engine/Classes/HUD.uc
@@ -246,8 +246,12 @@ simulated event PostRender( canvas Canvas )
 
 	if ( !PlayerOwner.bBehindView )
 	{
-		if (P != None)  //TMC changed ( (P != None) && (Item != None) )
+		if (P != None)  {//TMC changed ( (P != None) && (Item != None) )
 			P.RenderOverlays(Canvas);
+			if (P.GetHands() != None) {
+				P.GetHands().RenderRedDot(Canvas);
+			}
+		}
 	}
 
 //FIXMEJOE

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -2530,7 +2530,7 @@ SelectableVariants=(VariantName="Suppressor",VariantClass=class'SwatEquipment.SC
 SelectableVariants=(VariantName="Aimpoint + Suppressor",VariantClass=class'SwatEquipment.SCARHAsdMG')
 
 ;*****************************
-; SCAR-HA ASSAULT RIFLE
+; SCAR-H ASSAULT RIFLE with Aimpoint sight
 ; Based on SCAR-H
 ;*****************************
 [SwatEquipment.SCARHAMG]
@@ -2550,6 +2550,7 @@ IronSightRotationOffset=(Pitch=175,Yaw=0,Roll=0)
 ; IgnoreZoomSetting ignores the "Disable Zoom" option in the settings menu
 IgnoreZoomSetting=true
 ;ZoomBlurOverlay=Material'HUD.DefaultZoomBlurOverlay'
+bUsesRedDotSight=true
 ZoomedAimErrorModifier=0.5
 ZoomedFOV=30.0
 ZoomTime=0.50
@@ -2672,6 +2673,7 @@ Bulk=30.3
 FirstPersonModelClass=class'SwatEquipmentModels2.SCARHAsd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.SCARHAsd_ThirdPerson'
 ZoomBlurOverlay=Material'HUD.DefaultZoomBlurOverlay'
+bUsesRedDotSight=true
 
 ;; GUI
 GUIImage=material'gui_tex3.equip_scarhasd'
@@ -2822,6 +2824,7 @@ FirstPersonModelClass=class'SwatEquipmentModels2.M4A1A_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M4A1A_ThirdPerson'
 IronSightLocationOffset=(X=2,Y=-5.85,Z=1.475)
 IronSightRotationOffset=(Pitch=360,Yaw=0,Roll=0)
+bUsesRedDotSight=true
 
 ;; GUI
 WeaponCategory=WeaponClass_AssaultRifle
@@ -2978,6 +2981,7 @@ FirstPersonModelClass=class'SwatEquipmentModels2.M4A1ASD_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M4A1ASD_ThirdPerson'
 IronSightLocationOffset=(X=2,Y=-5.85,Z=1.475)
 IronSightRotationOffset=(Pitch=360,Yaw=0,Roll=0)
+bUsesRedDotSight=true
 
 ;; GUI
 ;GUIImage=material'bp_gui_tex.gui_M4v2_v01'
@@ -3121,6 +3125,7 @@ FirstPersonModelClass=class'SwatEquipmentModels2.M4A1CQBA_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M4A1CQBA_ThirdPerson'
 IronSightLocationOffset=(X=2,Y=-5.85,Z=1.475)
 IronSightRotationOffset=(Pitch=360,Yaw=0,Roll=0)
+bUsesRedDotSight=true
 
 ; 2.72kg + 300g flashlight + 300g aimpoint
 Weight=3.32
@@ -3220,6 +3225,7 @@ FirstPersonModelClass=class'SwatEquipmentModels2.M4A1CQBAsd_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.M4A1CQBAsd_ThirdPerson'
 IronSightLocationOffset=(X=2,Y=-5.85,Z=1.475)
 IronSightRotationOffset=(Pitch=360,Yaw=0,Roll=0)
+bUsesRedDotSight=true
 
 ; 2.72kg + 300g flashlight + 500g suppressor + 300g aimpoint
 Weight=3.82


### PR DESCRIPTION
Previously, the Aimpoint M2 had the red dot reticle baked into its texture, meaning the dot was static. In the real world, Aimpoints are a type of reflex sight, meaning they use a parallax effect to keep the reticle on target regardless of head motion. This PR adds the parallax effect. The implementation is a little hacky behind the scenes (hardcoded logic to turn the reticle on and off depending on weapon position), but it works well enough.

**Make sure to merge #677 before merging this PR.**