### PR TITLE
All weapon categories now use new `ZoomedFovModifier` property

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -185,7 +185,8 @@ LightstickThrowAnimPostfix="SMG"
 AimAnimation=WeaponAnimAim_SubmachineGun
 LowReadyAnimation=WeaponAnimLowReady_SubmachineGun
 IdleWeaponCategory=IdleWithSubmachineGun
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.75
 ZoomTime=0.25
 ViewInertia=0.35;
 MaxInertiaOffset=1.1
@@ -199,7 +200,8 @@ LightstickThrowAnimPostfix="HG"
 AimAnimation=WeaponAnimAim_Handgun
 LowReadyAnimation=WeaponAnimLowReady_Handgun
 IdleWeaponCategory=IdleWithHandgun
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=.8
 ZoomTime=0.25
 ViewInertia=0.25;
 MaxInertiaOffset=1
@@ -214,7 +216,8 @@ LightstickThrowAnimPostfix="M4"
 AimAnimation=WeaponAnimAim_MachineGun
 LowReadyAnimation=WeaponAnimLowReady_Machinegun
 IdleWeaponCategory=IdleWithG36
-ZoomedFOV=45.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.7
 ZoomTime=0.25
 ViewInertia=0.45;
 MaxInertiaOffset=1.3
@@ -228,7 +231,8 @@ LightstickThrowAnimPostfix="SG"
 Choke=0.85
 ;For 14" barrel shotgun like the M870, their choke value should be 1.51, this is as close as it can get to real life
 ;these values also fix the innacuracy of slugs and beanbag rounds
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.8
 ZoomTime=0.25
 ViewInertia=0.5;
 MaxInertiaOffset=1.3
@@ -246,7 +250,8 @@ RagdollDeathImpactMomentumMultiplier=0
 AimAnimation=WeaponAnimAim_Paintball
 LowReadyAnimation=WeaponAnimLowReady_Paintball
 IdleWeaponCategory=IdleWithPaintballGun
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.75
 ZoomTime=0.25
 ViewInertia=0.4;
 MaxInertiaOffset=1
@@ -258,7 +263,8 @@ OfficerMaxShotsWhenGassed=5
 ThirdPersonFireOffset=(X=0,Y=0,Z=0)
 RagdollDeathImpactMomentumMultiplier=15
 LightstickThrowAnimPostfix="SG"
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.8
 ZoomTime=0.25
 ViewInertia=0.5;
 MaxInertiaOffset=1.3
@@ -279,7 +285,8 @@ ComplianceAnimation=Compliance_Shotgun
 
 [SwatEquipment.GrenadeLauncherBase]
 IdleWeaponCategory=IdleWithG36
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.7
 ZoomTime=0.25
 ComplianceAnimation=Compliance_Shotgun
 ViewInertia=0.6;
@@ -1867,7 +1874,7 @@ Bulk=17.68
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels2.MP5_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.MP5_ThirdPerson'
-IronSightLocationOffset=(X=-1,Y=-6.22,Z=3.82)
+IronSightLocationOffset=(X=0,Y=-6.22,Z=3.82)
 IronSightRotationOffset=(Pitch=-145,Yaw=0,Roll=0)
 
 ;; GUI
@@ -5197,7 +5204,8 @@ RecoilForeDuration=0.15
 SemiRecoilBase=100
 ZoomedSemiRecoilBase=100
 ;Weapon Zoom
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.8
 ZoomTime=0.25
 ;Pawn reactions
 PlayerTasedDuration=17.0
@@ -5343,7 +5351,8 @@ RecoilForeDuration=0.15
 SemiRecoilBase=100
 ZoomedSemiRecoilBase=100
 ;Weapon Zoom
-ZoomedFOV=60.0
+bUseZoomFovModifier=true
+ZoomedFovModifier=0.8
 ZoomTime=0.25
 ;Pawn reactions
 PlayerTasedDuration=15.0
@@ -5541,8 +5550,6 @@ FlashlightRotation_1stPerson=(Pitch=0,Yaw=0,Roll=0)
 FlashlightPosition_3rdPerson=(X=0,Y=-11.8,Z=1.9)
 FlashlightRotation_3rdPerson=(Pitch=0,Yaw=-16384,Roll=0)
 ;Weapon Zoom
-ZoomedFOV=60.0
-ZoomTime=0.75
 LightstickThrowAnimPostfix="HG"
 
 ;; Damage
@@ -5706,9 +5713,6 @@ SemiRecoilBase=240
 ZoomedSemiRecoilBase=240
 AutoRecoilPerShot=60
 HasAttachedFlashlight=false
-;Weapon Zoom
-ZoomedFOV=35.0
-ZoomTime=0.75
 LightstickThrowAnimPostfix="M4"
 
 ;; Damage
@@ -6073,9 +6077,6 @@ RecoilForeDuration=0.5
 SemiRecoilBase=240
 AutoRecoilPerShot=60
 HasAttachedFlashlight=false
-;Weapon Zoom
-ZoomedFOV=35.0
-ZoomTime=0.75
 LightstickThrowAnimPostfix="M4"
 
 ;; Damage
@@ -6141,9 +6142,6 @@ RecoilForeDuration=0.6
 SemiRecoilBase=220
 AutoRecoilPerShot=40
 HasAttachedFlashlight=false
-;Weapon Zoom
-ZoomedFOV=45.0
-ZoomTime=0.5
 LightstickThrowAnimPostfix="SMG"
 
 ;; Damage


### PR DESCRIPTION
**#691 should be fixed before this PR is merged**

Adjust zoom for all weapon categories using the new `ZoomedFovModifier` property. 

Balancing zoom is tricky - excessive zoom robs the player of peripheral vision and hurts overall situational awareness, while inadequate zoom can make it difficult to aim at distant targets, particularly on a small monitor. Because engagements in vanilla SWAT 4/TSS maps usually take place at CQB ranges of 10 meters or less, I opted for less zoom/more peripheral vision. 

@eezstreet You may disagree with the way that I balanced zoom, so please test it and adjust if desired. Right now, zoom level is set per category of weapon, so it should only be necessary to test with one weapon in each category. 