### PR TITLE
Funtime Amusements briefing uses correct name/thumbnail for MP5SD5

### DIFF
--- a/System/SwatMissions.ini
+++ b/System/SwatMissions.ini
@@ -352,9 +352,9 @@ TimelineLongDescription=- SWAT arrives on scene and makes immediate tactical ent
 NewEquipmentName=Respirator
 NewEquipmentImage=Texture'gui_tex.equip_gasmask'
 NewEquipmentDescription=The respirator provides the wearer with immunity to CS gas and pepper spray.  Unfortunately it offers no ballistic protection.
-SecondEquipmentName=MP5SD6
-SecondEquipmentImage=material'gui_sas.mp5sd_gui'
-SecondEquipmentDescription=The MP5SD6 is a variant of the MP5 equipped with an integrated suppressor and collapsible stock. It is very popular among covert-ops forces and is deployed in stealth operations around the globe. This weapon is chambered in 9x19mm Parabellum rounds.
+SecondEquipmentName=MP5SD5
+SecondEquipmentImage=material'gui_tex3.equip_mp5sd5'
+SecondEquipmentDescription=The MP5SD5 is a variant of the MP5 equipped with an integrated suppressor. It is very popular among covert-ops forces and is deployed in stealth operations around the globe. This weapon is chambered in 9x19mm Parabellum rounds.
 
 ;Loading Info
 LoadingText=1401 Gower Street, FunTime Amusement Arcade


### PR DESCRIPTION
@eezstreet I am not 100% certain this is the only change that's needed. My local copy of `SwatMissions.ini` has equipment unlock entries which are not in the repository and I didn't add. Is some or all of the unlock data in `SwatMissions.ini` generated at runtime? Where did these entries come from?

<img width="1258" height="662" alt="SwatMissions INI" src="https://github.com/user-attachments/assets/71222015-fabe-404b-b7d4-460701eee146" />

If the unlock data in `SwatMissions.ini` is generated at runtime, then the changes I've made in this PR might be lost. 