### PR TITLE
SpeechCommandGrammar: fix many issues, add documentation.

### DIFF
--- a/System/SpeechCommandGrammar.xml
+++ b/System/SpeechCommandGrammar.xml
@@ -1,15 +1,36 @@
 <!-- This file defines the Grammar to be recognized in SWAT 4 -->
 
-<!-- If you change this file, use Source/Libraries/SAPI5.1/Bin/GramComp.exe to test it -->
+<!-- If you change this file, install the Microsoft Speech SDK 5.1 and use GramComp.exe to test this file -->
 
 <!-- 
 NOTES:
 
  - "see yes" is used as a stand-in for "CS" because the game doesn't understand letters 
- - ? denotes an optional word
- - ... denotes places where you can say whatever you want
- - What does + mean?
+ - ? denotes a word is optional when used at the beginning of the word
+ - ... is a wildcard that can only be used at the end of a phrase. See "Wildcard Quirks" below.
+ - * and *+ are wildcards. See "Wildcard Quirks" below.
+ - + means require more confidence before recognizing this word
+ - - means require less confidence before recognizing this word
  - Be careful of similar-sounding phrases, for example "cover" and "cuff her"
+ 
+WILDCARD QUIRKS:
+The rules for wildcards are complex and confusing. Please read carefully.
+- if ... appears at the beginning of a phrase, it is ignored.
+
+- If ... appears in the middle of a phrase, the Speech SDK is supposed to treat this as a wildcard, allowing the user
+to insert any number of arbitrary words at this point in the phrase. However, it's unreliable, working for some phrases
+and not others. For example, "wedge ... door" will almost always recognize "wedge the door" or "wedge this door", but
+"open ... quietly" almost never recognizes "open it quietly" or "open this door quietly".
+
+- If ... appears at the end of a phrase, the user may add any number of arbitrary words to the end of the phrase. WARNING:
+a ... wildcard at the end of the phrase will be ignored if the phrase contains an * or *+ wildcard!
+
+- If * is used anywhere in the phrase, the user MUST insert exactly one arbitrary word into the phrase here. HOWEVER, if 
+the * is used between two explicit words, the Speech SDK will often hallucinate a word, making this wildcard appear optional.
+For example, if the phrase is "raise * hands", and the user just says "raise hands", the SDK will often read this as "raise 
+a hands" or "raise I hands" and accept it.
+
+- If *+ is inserted anywhere in a phrase, the user MUST insert one or more arbitrary words into this part of the phrase.
 
 -->
 
@@ -42,11 +63,12 @@ NOTES:
 			<PHRASE VALSTR="Command_StackUpAndTryDoor">Try ... door ...</PHRASE>
 			<PHRASE VALSTR="Command_StackUpAndTryDoor">Check the door.</PHRASE>
 
-			<PHRASE VALSTR="Command_PickLock">Pick ... lock.</PHRASE>
-			<PHRASE VALSTR="Command_PickLock">Unlock ...</PHRASE>
-			<PHRASE VALSTR="Command_PickLock">Open ... quietly</PHRASE>
-			<PHRASE VALSTR="Command_PickLock">Quietly ... open ...</PHRASE>
-			<PHRASE VALSTR="Command_PickLock">Take care ... lock.</PHRASE>
+			<PHRASE VALSTR="Command_PickLock">Pick *+ lock.</PHRASE>
+			<PHRASE VALSTR="Command_PickLock">Unlock *+</PHRASE>
+			<PHRASE VALSTR="Command_PickLock">Open *+ quietly</PHRASE>
+			<PHRASE VALSTR="Command_PickLock">Quietly *+ open</PHRASE>
+			<PHRASE VALSTR="Command_PickLock">Quietly open *+</PHRASE>
+			<PHRASE VALSTR="Command_PickLock">Take care *+ lock</PHRASE>
 
 			<PHRASE VALSTR="Command_MoveAndClear">Move ?and +clear ...</PHRASE>
 			<PHRASE VALSTR="Command_MoveAndClear">Move in ?and +clear</PHRASE>
@@ -56,7 +78,7 @@ NOTES:
 			<PHRASE VALSTR="Command_OpenAndMakeEntry">Open ?it ?the ?that ?door ?over ?there ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_OpenAndClear">Get through ?there ?the ?that ?door, ?and ?go ?clear ...</PHRASE>
 			<PHRASE VALSTR="Command_OpenAndMakeEntry">Make entry ?and ?clear ?that ?it ?the ?room ?door ?area ?sector</PHRASE>
-            
+
 			<PHRASE VALSTR="Command_OpenBangAndClear">?Open ?it ?the ?that ?door ?over ?there ?throw ?a ?flash bang ?and clear ...</PHRASE>
 			<PHRASE VALSTR="Command_OpenBangAndMakeEntry">Open ?it ?that ?the ?door ?over ?there ?throw ?a ?flash bang ?and ?prepare ?to make entry ...</PHRASE>
 			<PHRASE VALSTR="Command_OpenBangAndMakeEntry">Make Entry ?with ?a ?flash bang ?and ?clear ...</PHRASE>
@@ -66,26 +88,29 @@ NOTES:
 			<PHRASE VALSTR="Command_OpenGasAndMakeEntry">?Open, see yes ?gas ?grenade, and clear.</PHRASE>
 			<PHRASE VALSTR="Command_OpenGasAndMakeEntry">?Open ?it ?the ?that ?door ?room ?over ?there ?and ?throw ?toss ?a ?see ?yes ?CS +gas ?grenade and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_OpenGasAndMakeEntry">?Open, see yes ?gas ?grenade, and ?prepare ?to make entry.</PHRASE>
-            
+
 			<PHRASE VALSTR="Command_StingAndClear">Sting ?it ?that ?the ?room ?door ?over ?there and clear ...</PHRASE>
 			<PHRASE VALSTR="Command_OpenStingAndClear">?Open ?it ?that ?the ?room ?door ?over ?there ?and ?throw ?toss ?a sting ?grenade and clear ...</PHRASE>
 			<PHRASE VALSTR="Command_OpenStingAndMakeEntry">?Open ?it ?that ?the ?room ?door ?over ?there ?and ?throw ?toss ?a sting ?grenade and ?prepare ?to make entry.</PHRASE>
 
-			<PHRASE VALSTR="Command_FallIn">Fall in ?on ?me.</PHRASE>
+			<PHRASE VALSTR="Command_FallIn">Fall in ?behind ?on ?me.</PHRASE>
 			<PHRASE VALSTR="Command_FallIn">Follow me</PHRASE>
 			<PHRASE VALSTR="Command_FallIn">Come to ?me ?my ?position.</PHRASE>
 			<PHRASE VALSTR="Command_FallIn">Return to ?me ?my ?position.</PHRASE>
-                        <PHRASE VALSTR="Command_FallIn">On my six</PHRASE>
-                        <PHRASE VALSTR="Command_FallIn">Behind me</PHRASE>
+			<PHRASE VALSTR="Command_FallIn">On my six</PHRASE>
+			<PHRASE VALSTR="Command_FallIn">Behind me</PHRASE>
 
-			<PHRASE VALSTR="Command_MoveTo">Get ... +there.</PHRASE>
-			<PHRASE VALSTR="Command_MoveTo">Move ... +there.</PHRASE>
-			<PHRASE VALSTR="Command_MoveTo">+Go ... +there.</PHRASE>
+			<PHRASE VALSTR="Command_MoveTo">Get *+ +there.</PHRASE>
+			<PHRASE VALSTR="Command_MoveTo">Move +there.</PHRASE>
+			<PHRASE VALSTR="Command_MoveTo">Move *+ +there.</PHRASE>
+			<PHRASE VALSTR="Command_MoveTo">+Go +there.</PHRASE>
+			<PHRASE VALSTR="Command_MoveTo">+Go *+ +there.</PHRASE>
 			<PHRASE VALSTR="Command_MoveTo">Take position ...</PHRASE>
 
-			<PHRASE VALSTR="Command_Cover">... Provide +cover.</PHRASE>
-			<PHRASE VALSTR="Command_Cover">Eyes on and provide +cover.</PHRASE>
+			<PHRASE VALSTR="Command_Cover">Provide +cover.</PHRASE>
+			<PHRASE VALSTR="Command_Cover">*+ provide +cover.</PHRASE>
 			<PHRASE VALSTR="Command_Cover">+Cover ?the ?that ?area</PHRASE>
+			<PHRASE VALSTR="Command_Cover">+Cover me</PHRASE>
 			<PHRASE VALSTR="Command_Cover">Abort</PHRASE>
 			<PHRASE VALSTR="Command_Cover">Cancel</PHRASE>
 
@@ -99,9 +124,11 @@ NOTES:
 			<PHRASE VALSTR="Command_CloseDoor">Shut ...</PHRASE>
 
 			<PHRASE VALSTR="Command_RemoveWedge">Remove ... +wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_RemoveWedge">Clear ... +wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_RemoveWedge">Get ... +wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_RemoveWedge">Take ... +wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_RemoveWedge">Clear *+ +wedge</PHRASE>
+			<PHRASE VALSTR="Command_RemoveWedge">Get *+ +wedge</PHRASE>
+			<PHRASE VALSTR="Command_RemoveWedge">Get *+ +wedge *+</PHRASE>
+			<PHRASE VALSTR="Command_RemoveWedge">Take *+ +wedge</PHRASE>
+			<PHRASE VALSTR="Command_RemoveWedge">Take *+ +wedge *+</PHRASE>
 
 			<PHRASE VALSTR="Command_SecureEvidence">Secure ?that ?those ?evidence ?drugs ?drug ?bag ?gun ?guns</PHRASE>
 			<PHRASE VALSTR="Command_SecureEvidence">Grab ?that ?those ?evidence ?drugs ?drug ?bag ?gun ?guns</PHRASE>
@@ -131,173 +158,221 @@ NOTES:
 			<PHRASE VALSTR="Command_MirrorCorner">Look ?around ?the corner ...</PHRASE>
 			<PHRASE VALSTR="Command_MirrorCorner">?Take ?a peek ?around ?the corner ...</PHRASE>
 
-			<PHRASE VALSTR="Command_Deploy_Wedge">Deploy ... +wedge</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_Wedge">Use ... +wedge</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_Wedge">Place ... +wedge</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_Wedge">Wedge ... door</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_BreachingShotgun">Deploy ... ?breaching +shotgun.</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_BreachingShotgun">Use ... ?breaching +shotgun.</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Deploy ... less lethal ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Deploy ... bean bag ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Use ... less lethal ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Use ... bean bag ... </PHRASE>
-			<PHRASE VALSTR="Command_Deploy_GrenadeLauncher">Deploy ... launcher.</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_GrenadeLauncher">Use ... launcher.</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_Taser">Deploy ... +taser ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_Taser">Use ... +taser ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_Flashbang">+Deploy ... +bang ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_Flashbang">Throw ... flash ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_Flashbang">Chuck ... flash ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_Flashbang">Throw ... ?flash bang ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_Flashbang">Chuck ... ?flash bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Deploy +wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Deploy *+ +wedge</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Deploy *+ +wedge *+</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Use * +wedge</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Use * +wedge *+</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Place * +wedge</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Place * +wedge *+</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Wedge">Wedge ... door</PHRASE> <!-- Usually works for some reason... -->
+			<PHRASE VALSTR="Command_Deploy_BreachingShotgun">Deploy ?a ?the ?your ?breaching +shotgun ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_BreachingShotgun">Use ?a ?the ?your ?breaching +shotgun ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_BreachingShotgun">Use * ?breaching +shotgun.</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Deploy ?a ?the ?your less lethal ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Deploy ?a ?the ?your bean bag ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Use ?the ?your ?a less lethal ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_LessLethalShotgun">Use ?the ?your ?a bean bag ... </PHRASE>
+			<PHRASE VALSTR="Command_Deploy_GrenadeLauncher">Deploy ?a ?the ?your ?grenade ?canister ?munition launcher.</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_GrenadeLauncher">Use ?a ?the ?your ?grenade ?canister ?munition launcher.</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Taser">Deploy ?a ?the ?your +taser ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Taser">Use ?a ?the ?your +taser ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">+Deploy +bang</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">+Deploy *+ +bang</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">+Deploy *+ +bang *+</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">Throw ?in ?a ?the ?your flash ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">Throw ?in ?a ?the ?your bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">Chuck ?in ?a ?the ?your flash ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">Chuck ?in ?a ?the ?your bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">Toss ?in ?a ?the ?your flash ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_Flashbang">Toss ?in ?a ?the ?your bang ...</PHRASE>
 			<PHRASE VALSTR="Command_Deploy_CSGas">+Deploy see yes ?gas...</PHRASE>
 			<PHRASE VALSTR="Command_Deploy_CSGas">+Deploy ?tear gas ...</PHRASE>
 			<PHRASE VALSTR="Command_Deploy_CSGas">+Deploy ?tear ?CS gas ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_CSGas">Throw ... ?tear ?CS gas ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_CSGas">Chuck ... ?tear ?CS gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSGas">Throw ?in ?a ?the ?your ?tear ?CS gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSGas">Throw ?in ?a ?the ?your ?tear see yes ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSGas">Chuck ?in ?a ?the ?your ?tear ?CS gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSGas">Chuck ?in ?a ?the ?your ?tear see yes ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSGas">Toss ?in ?a ?the ?your ?tear ?CS gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSGas">Toss ?in ?a ?the ?your ?tear see yes ...</PHRASE>
 			<PHRASE VALSTR="Command_Deploy_StingGrenade">+Deploy sting ?grenade ...</PHRASE>
 			<PHRASE VALSTR="Command_Deploy_StingGrenade">+Deploy +stinger ?grenade ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_StingGrenade">Throw ... sting ?grenade ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_StingGrenade">Chuck ... sting ?grenade ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_StingGrenade">Throw ... +stinger ?grenade ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_StingGrenade">Chuck ... +stinger ?grenade ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_PepperSpray">Deploy ... pepper +spray ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_PepperSpray">Use ... pepper +spray ...</PHRASE>
-                        <PHRASE VALSTR="Command_Deploy_PepperSpray">+Spray ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_C2Charge">Deploy see two.</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_C2Charge">Use see two.</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_CSBallLauncher">Deploy ... pepper ?gun ...</PHRASE>
-			<PHRASE VALSTR="Command_Deploy_CSBallLauncher">Use ... pepper ?gun ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_StingGrenade">Throw ?in ?a ?the ?your sting ?grenade ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_StingGrenade">Chuck ?in ?a ?the ?your sting ?grenade ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_StingGrenade">Throw ?in ?a ?the ?your +stinger ?grenade ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_StingGrenade">Chuck ?in ?a ?the ?your +stinger ?grenade ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_PepperSpray">Deploy ?the ?your pepper +spray ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_PepperSpray">Use ?the ?your ?some pepper +spray ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_PepperSpray">+Spray ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_C2Charge">Deploy see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_C2Charge">Use see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSBallLauncher">Deploy ?the ?your pepper ?gun ...</PHRASE>
+			<PHRASE VALSTR="Command_Deploy_CSBallLauncher">Use ?a ?the ?your pepper ?gun ...</PHRASE>
 			<PHRASE VALSTR="Command_Deploy_Lightstick">?Mark ?it ?with ?Deploy ?a +light stick ...</PHRASE>
 
 			<PHRASE VALSTR="Command_LeaderThrowAndClear">Leader Throw ?and Clear</PHRASE>
-			<PHRASE VALSTR="Command_LeaderThrowAndClear">Let ... throw ... clear</PHRASE>
-			<PHRASE VALSTR="Command_BreachLeaderThrowAndClear">Breach ... leader throw and ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_BreachLeaderThrowAndClear">Breach ... let me ... and ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_OpenLeaderThrowAndClear">Open ... leader throw and ... clear ...</PHRASE>
+			<PHRASE VALSTR="Command_LeaderThrowAndClear">Let *+ throw *+ clear</PHRASE>
+			<PHRASE VALSTR="Command_BreachLeaderThrowAndClear">Breach, leader throw, and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_BreachLeaderThrowAndClear">Breach *+ leader throw and *+ clear</PHRASE>
+			<PHRASE VALSTR="Command_BreachLeaderThrowAndClear">Breach *+ leader throw and *+ clear *+</PHRASE>
+			<PHRASE VALSTR="Command_BreachLeaderThrowAndClear">Breach, let me *+ and *+ clear</PHRASE>
+			<PHRASE VALSTR="Command_OpenLeaderThrowAndClear">Open, leader throw, and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_OpenLeaderThrowAndClear">Open, *+ leader throw, and *+ clear</PHRASE>
+			<PHRASE VALSTR="Command_OpenLeaderThrowAndClear">Open, *+ leader throw, and *+ clear *+</PHRASE>
 
-			<PHRASE VALSTR="Command_C2AndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two and ... clear ...</PHRASE>
-    			<PHRASE VALSTR="Command_C2BangAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a ?flash +bang ?grenade ?and ... clear ...</PHRASE>
-    			<PHRASE VALSTR="Command_C2GasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a ?CS ?see ?yes +gas ?grenade ?and ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_C2GasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a see yes ?gas ?grenade ?and ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_C2GasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a CS ?gas ?grenade ?and ... clear ...</PHRASE>
-    			<PHRASE VALSTR="Command_C2StingAndClear">?Break ?Open Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a +sting ?grenade ?and ... clear ...</PHRASE>
-    			<PHRASE VALSTR="Command_C2LeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?let ?me ?the ?leader +throw ...</PHRASE>
-    			<PHRASE VALSTR="Command_C2AndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two and ?prepare ?to make entry.</PHRASE>
+			<PHRASE VALSTR="Command_C2AndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_C2AndClear">*+ +see +two ?and *+ clear</PHRASE>
+			<PHRASE VALSTR="Command_C2AndClear">*+ +see +two ?and *+ clear *+</PHRASE>
+			<PHRASE VALSTR="Command_C2BangAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a ?flash +bang ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_C2GasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a ?CS ?see ?yes +gas ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_C2GasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a see yes ?gas ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_C2GasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a CS ?gas ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_C2StingAndClear">?Break ?Open Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?throw ?toss ?a +sting ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_C2LeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?let ?me ?the ?leader +throw ...</PHRASE>
+			<PHRASE VALSTR="Command_C2AndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_C2BangAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?deploy ?throw ?toss ?a ?flash +bang ?grenade ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_C2GasAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?deploy ?throw ?toss ?a ?tear ?see ?yes ?CS +gas ?grenade ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_C2GasAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?deploy ?throw ?toss ?a see yes ?gas ?grenade ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_C2StingAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?deploy ?throw ?toss ?a +sting ?grenade ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_C2LeaderThrowAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with +see +two ?and ?wait ?hold ?back ?for +leader ?throw ?and ?prepare ?to make entry.</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun and ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunBangAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a ?flash +bang ?grenade ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunGasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a ?see ?yes ?CS +gas ?grenade ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunGasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a see yes ?gas ?grenade ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunStingAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a +sting ?grenade ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and wait for me ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and let me ... clear ...</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and +leader ... clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunBangAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?in ?a flash ?bang ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunBangAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?in ?a ?flash bang ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunGasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?in ?a ?see ?yes ?CS +gas ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunGasAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?in ?a see yes ?gas ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunStingAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?in ?a +sting ?grenade ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and wait for me ?to ?and clear ...</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and let me *+ clear</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndClear">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and +leader *+ clear</PHRASE>
 			<PHRASE VALSTR="Command_ShotgunAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_ShotgunBangAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a ?flash +bang ?grenade ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_ShotgunGasAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a ?see ?yes ?CS +gas ?grenade ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_ShotgunGasAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a see yes ?gas ?grenade ?and ?prepare ?to make entry.</PHRASE>
 			<PHRASE VALSTR="Command_ShotgunStingAndMakeEntry">?Break ?Open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and ?throw ?toss ?a +sting ?grenade ?and ?prepare ?to make entry.</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndMakeEntry">?Break ?open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and wait for me ... make entry.</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndMakeEntry">?Break ?open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and let me throw ... make entry.</PHRASE>
-			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndMakeEntry">?Break ?open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and leader throw ... make entry.</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndMakeEntry">?Break ?open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and wait for me *+ make entry.</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndMakeEntry">?Break ?open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and let me throw *+ make entry.</PHRASE>
+			<PHRASE VALSTR="Command_ShotgunLeaderThrowAndMakeEntry">?Break ?open ?Breach ?it ?the ?that ?room ?door ?over ?there ?with ?a ?the ?breaching shot gun ?and leader throw *+ make entry.</PHRASE>
 
-			<PHRASE VALSTR="Command_CleanSweep">... sweep ...</PHRASE>
-			<PHRASE VALSTR="Command_CleanSweep">Search ...</PHRASE>
-			<PHRASE VALSTR="Command_CleanSweep">Fan out ...</PHRASE>
+			<PHRASE VALSTR="Command_CleanSweep">*+ sweep</PHRASE>
+			<PHRASE VALSTR="Command_CleanSweep">Sweep ...</PHRASE>
+			<PHRASE VALSTR="Command_CleanSweep">*+ sweep *+</PHRASE>
+			<PHRASE VALSTR="Command_CleanSweep">Search *+</PHRASE>  <!-- ... at the end does not work here -->
+			<PHRASE VALSTR="Command_CleanSweep">Fan out *+</PHRASE> <!-- ... at the end does not work here -->
 			<PHRASE VALSTR="Command_RestrainAll">Restrain all ...</PHRASE>
-			<PHRASE VALSTR="Command_RestrainAll">Cuff all ...</PHRASE>
-			<PHRASE VALSTR="Command_SecureAll">Secure all ...</PHRASE>
-			<PHRASE VALSTR="Command_SecureAll">Grab all ...</PHRASE>
-			<PHRASE VALSTR="Command_DisableAll">Disable all ...</PHRASE>
+			<PHRASE VALSTR="Command_RestrainAll">Restrain everyone ...</PHRASE>
+			<PHRASE VALSTR="Command_RestrainAll">Cuff all *+</PHRASE>
+			<PHRASE VALSTR="Command_RestrainAll">Cuff everyone</PHRASE>
+			<PHRASE VALSTR="Command_SecureAll">Secure all</PHRASE>
+			<PHRASE VALSTR="Command_SecureAll">Secure all *+</PHRASE> <!-- ... at the end does not work here -->
+			<PHRASE VALSTR="Command_SecureAll">+Grab all *+</PHRASE>
+			<PHRASE VALSTR="Command_SecureAll">Grapple evidence</PHRASE> <!-- It really struggles with "grab all"-->
+			<PHRASE VALSTR="Command_DisableAll">Disable all ?bombs ?traps ...</PHRASE>
+			<PHRASE VALSTR="Command_DisableAll">Disable everything ...</PHRASE>
 			<PHRASE VALSTR="Command_DisableAll">Disarm all ...</PHRASE>
+			<PHRASE VALSTR="Command_DisableAll">Disarm everything ...</PHRASE>
 
 			<PHRASE VALSTR="Command_ReportIn">Report in.</PHRASE>
-			<PHRASE VALSTR="Command_ReportIn">... status report.</PHRASE>
+			<PHRASE VALSTR="Command_ReportIn">Status report.</PHRASE>
+			<PHRASE VALSTR="Command_ReportIn">?Give ?me ?let's ?hear ?provide ?make ?a status report.</PHRASE>
 			<PHRASE VALSTR="Command_ReportIn">Sound off.</PHRASE>
 			
-			<PHRASE VALSTR="Command_Request_Flashbang">I need ... ?flash bang ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Flashbang">Requesting ... ?flash bang ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Flashbang">Request ... ?flash bang ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Flashbang">Give ?me ... ?flash bang ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Flashbang">Hand ?me ... ?flash bang ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Flashbang">Pass ?me ... ?flash bang ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_CSGas">I need ... ?see ?yes ?tear gas ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_CSGas">Requesting ... ?see ?yes ?tear gas ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_CSGas">Request ... ?see ?yes ?tear gas ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_CSGas">Give ?me ... ?see ?yes ?tear gas ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_CSGas">Hand ?me ... ?see ?yes ?tear gas ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_CSGas">Pass ?me ... ?see ?yes ?tear gas ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">I need ... stinger ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Requesting ... stinger ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Request ... stinger ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Give ?me ... stinger ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Hand ?me ... stinger ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Pass ?me ... stinger ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">I need ... sting ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Requesting ... sting ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Request ... sting ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Give ?me ... sting ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Hand ?me ... sting ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Stinger">Pass ?me ... sting ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Pepperspray">I need ... pepper ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Pepperspray">Requesting ... pepper ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Pepperspray">Request ... pepper ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Pepperspray">Give ?me ... pepper ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Pepperspray">Hand ?me ... pepper ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Pepperspray">Pass ?me ... pepper ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Optiwand">I need ... ?opti wand ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Optiwand">Requesting ... ?opti wand ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Optiwand">Request ... ?opti wand ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Optiwand">Give ?me ... ?opti wand ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Optiwand">Hand ?me ... ?opti wand ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Optiwand">Pass ?me ... ?opti wand ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Wedge">I need ... ?door wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Wedge">Requesting ... ?door wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Wedge">Request ... ?door wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Wedge">Give ?me ... ?door wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Wedge">Hand ?me ... ?door wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Wedge">Pass ?me ... ?door wedge ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Lightstick">I need ... ?light ?glow stick ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Lightstick">Requesting ... ?light ?glow stick ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Lightstick">Request ... ?light ?glow stick ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Lightstick">Give ?me ... ?light ?glow stick ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Lightstick">Hand ?me ... ?light ?glow stick ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_Lightstick">Pass ?me ... ?light ?glow stick ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_C2">I need ... see two ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_C2">Requesting ... see two ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_C2">Request ... see two ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_C2">Give ?me ... see two ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_C2">Hand ?me ... see two ...</PHRASE>
-			<PHRASE VALSTR="Command_Request_C2">Pass ?me ... see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">I need ?a ?your ?flash bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">Requesting ?flash bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">Requesting *+ bang</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">Requesting *+ bang *+</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">Request *+ ?flash bang</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">Give ?me ?a ?one ?your ?spare ?flash bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">Hand ?me ?a ?one ?your ?spare ?flash bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Flashbang">Pass ?me ?a ?one ?your ?spare ?flash bang ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">I need ?a ?your ?spare see yes ?tear ?gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">I need ?a ?your ?spare ?see ?yes ?tear gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Requesting .?a ?one ?your ?spare ?see ?yes ?tear gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Requesting .?a ?one ?your ?spare see yes ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Request *+ ?see ?yes ?tear gas</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Give ?me ?a ?one ?your ?spare ?see ?yes ?tear gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Give ?me ?a ?one ?your ?spare see yes ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Hand ?me ?a ?one ?your ?spare ?see ?yes ?tear gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Hand ?me ?a ?one ?your ?spare see yes ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Pass ?me ?a ?one ?your ?spare ?see ?yes ?tear gas ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_CSGas">Pass ?me ?a ?one ?your ?spare see yes ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">I need ?a ?one ?your ?spare stinger ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Requesting ?a ?one ?your ?spare stinger ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Request ?a ?one ?your ?spare stinger ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Give ?me ?a ?one ?your ?spare stinger ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Hand ?me ?a ?one ?your ?spare stinger ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Pass ?me ?a ?one ?your ?spare stinger ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">I need ?a ?one ?your ?spare sting ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Requesting ?a ?one ?your ?spare sting ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Request ?a ?one ?your ?spare sting ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Give ?me ?a ?one ?your ?spare sting ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Hand ?me ?a ?one ?your ?spare sting ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Stinger">Pass ?me ?a ?one ?your ?spare sting ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Pepperspray">I need ?the ?some pepper ?spray</PHRASE>
+			<PHRASE VALSTR="Command_Request_Pepperspray">Requesting ?the ?some pepper ?spray</PHRASE>
+			<PHRASE VALSTR="Command_Request_Pepperspray">Request ?some ?your ?spare pepper ?spray</PHRASE>
+			<PHRASE VALSTR="Command_Request_Pepperspray">Give ?me ?your ?some ?spare pepper ?spray</PHRASE>
+			<PHRASE VALSTR="Command_Request_Pepperspray">Hand ?me ?your ?some ?spare pepper ?spray</PHRASE>
+			<PHRASE VALSTR="Command_Request_Pepperspray">Pass ?me ?your ?some ?spare pepper ?spray</PHRASE>
+			<PHRASE VALSTR="Command_Request_Optiwand">I need ?an ?the ?your ?opti wand ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Optiwand">Requesting ?an ?the ?your ?opti wand ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Optiwand">Request ?an ?the ?your ?opti wand ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Optiwand">Give ?me .?an ?the ?your ?opti wand ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Optiwand">Hand ?me ?an ?the ?your ?opti wand ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Optiwand">Pass ?me ?an ?the ?your ?opti wand ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Wedge">I need ?a ?one ?your ?spare ?door wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Wedge">Requesting ?a ?one ?your ?spare ?door wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Wedge">Request ?a ?one ?your ?spare ?door wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Wedge">Give ?me ?a ?one ?your ?spare ?door wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Wedge">Hand ?me ?a ?one ?your ?spare ?door wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Wedge">Pass ?me ?a ?one ?your ?spare ?door wedge ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Lightstick">I need ?a ?one ?your ?spare ?light ?glow stick ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Lightstick">Requesting .?a ?one ?your ?spare ?light ?glow stick ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Lightstick">Request ?a ?one ?your ?spare ?light ?glow stick ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Lightstick">Give ?me ?a ?one ?your ?spare ?light ?glow stick ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Lightstick">Hand ?me ?a ?one ?your ?spare ?light ?glow stick ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_Lightstick">Pass ?me ?a ?one ?your ?spare ?light ?glow stick ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_C2">I need ?a ?some ?your ?spare see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_C2">Requesting ?a ?some ?your ?spare see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_C2">Request ?a ?some ?your ?spare see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_C2">Give ?me ?a ?some ?your ?spare see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_C2">Hand ?me ?a ?some ?your ?spare see two ...</PHRASE>
+			<PHRASE VALSTR="Command_Request_C2">Pass ?me ?a ?some ?your ?spare see two ...</PHRASE>
 		</LIST>
 	</RULE>
 
 	<RULE NAME="Actions" TOPLEVEL="ACTIVE">
 		<LIST PROPNAME="Actions">
-			<PHRASE VALSTR="TOCReport">Talk, this is entry team ...</PHRASE>
-			<PHRASE VALSTR="TOCReport">Entry team to talk ...</PHRASE>
-			<PHRASE VALSTR="TOCReport">Talk, we ...</PHRASE>
-			<PHRASE VALSTR="TOCReport">Talk, there's ...</PHRASE>
-			<PHRASE VALSTR="TOCReport">Talk, there appears ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Police ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Arms up ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Arms where ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Hands up ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Hands in the ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Hands to the ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Hands where ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Get down ...</PHRASE>
+			<PHRASE VALSTR="TOCReport">Talk, this is entry team *+</PHRASE>
+			<PHRASE VALSTR="TOCReport">Entry team to talk *+</PHRASE>
+			<PHRASE VALSTR="TOCReport">Talk, we *+</PHRASE>
+			<PHRASE VALSTR="TOCReport">Talk, there's *+</PHRASE>
+			<PHRASE VALSTR="TOCReport">Talk, there appears *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Police ...</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ police ...</PHRASE>
+			<PHRASE VALSTR="Compliance">Arms up ...</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ arms up</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ arms up *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Arms where *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ arms where *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Hands up ...</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ hands up</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ hands up *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Hands in the *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ hands in the *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Hands to the *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ hands to the *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Hands where *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ hands where *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ hands where *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Get down ...</PHRASE>
 			<PHRASE VALSTR="Compliance">Comply ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... SWAT ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... search warrant ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... Drop ?your ?the weapon ...</PHRASE>
-			<PHRASE VALSTR="Compliance">... see your hands ...</PHRASE>
-			<PHRASE VALSTR="Compliance">Show ?me ?us your hands.</PHRASE>
+			<PHRASE VALSTR="Compliance">SWAT *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ SWAT *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ search warrant ...</PHRASE>
+			<PHRASE VALSTR="Compliance">Drop ?your ?the weapon *+</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ see your hands</PHRASE>
+			<PHRASE VALSTR="Compliance">*+ see your hands *+</PHRASE>
+			<PHRASE VALSTR="Compliance">Show ?me ?us your hands</PHRASE>
 		</LIST>
     	</RULE>
 


### PR DESCRIPTION
Previously, `SpeechCommandGrammar.xml` made heavy use of the `...` wildcard. This is a valid wildcard in SAPI 5.1; the problem is that it doesn't really work.

- The `...` wildcard _never_ works correctly when used at the beginning of a phrase, like "... hands up".
- The `...` wildcard very rarely works when used in the middle of a phrase, like "pass ... flash bang".
- The `...` wildcard usually, but not always works when used at the end of a phrase, like "restrain all ...".

The wildcard is supposed to allow the user to insert any number of arbitrary words into that part of the phrase, but because it usually doesn't work correctly, many speech commands did not work unless the user avoided the wildcard. For example, for the phrase "... hands up ...", the Speech SDK would recognize "hands up" but not "put your hands up". The "shotgun, (grenade), and clear" commands didn't work if the user said "and" because they were formatted to rely on the wildcard to handle "and".

I researched the SAPI 5.1 XML syntax and found that the `*` and `*+` wildcards can be used as an alternative to `...`. Unfortunately, unlike `...`, the asterisk wildcards require the user to insert at least one arbitrary word. For example, if the phrase is "deploy *+ lightstick", the Speech SDK will accept "deploy a lightstick" or "deploy your lightstick" but not "deploy lightstick". This requires us to create more variations for some phrases when we use the `*` or `*+` wildcards.

I went through the entire `SpeechCommandGrammar.xml` to fix problematic entries, and greatly expanded the documentation at the top of the file to help prevent confusion in the future.

Fixes #693 