### PR TITLE
Ballistic damage adjustment

### DIFF
--- a/Source/Unreal/Engine/Classes/Equipment/FiredWeapon.uc
+++ b/Source/Unreal/Engine/Classes/Equipment/FiredWeapon.uc
@@ -852,6 +852,11 @@ simulated function bool HandleBallisticImpact(
     //consider adding internal damage
     if (!PenetratesVictim)
         Damage += Ammo.InternalDamage;
+    else
+    {
+	if (Victim.isa('SwatPawn') || Victim.isa('SwatPlayer') )
+        	 Damage +=  ( Ammo.InternalDamage /2 );
+    }
 
     //apply any external damage modifiers (maintained by the Repo)
     ExternalDamageModifier = Level.GetRepo().GetExternalDamageModifier( Owner, Victim );


### PR DESCRIPTION
Here we are in the case where the victim is without an armor/helmet OR the bullet pentrated the armor/helmet. The penetration of the bullet makes no internal damage at all. It took me 5 AK FMJs to get down a unarmored suspect...

//consider adding internal damage
    if (!PenetratesVictim)
        Damage += Ammo.InternalDamage;

Now I corrected the function like that , so you get half internal damage if a bullet penetrates. On unarmored targets: JHP are still more effective but FMJ/AP/JSP are not that useless anymore....
On armored targets:   FMJ/AP/JSP are more effective

//consider adding internal damage
    if (!PenetratesVictim)
        Damage += Ammo.InternalDamage;

    else
    {
        if (Victim.isa('SwatPawn') || Victim.isa('SwatPlayer') )
             Damage +=  ( Ammo.InternalDamage /2 );
    }

Of course it works BOTH WAYS!