### PR TITLE
SwatOfficer find engage point sleep time reduced

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/MoveOfficerToEngageAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/MoveOfficerToEngageAction.uc
@@ -23,8 +23,10 @@ var private NavigationPoint		PointToEngageFrom;
 var private	name				RoomNameToEngageFrom;
 
 // time between trying finding a point to engage from
-const kMinSleepTimeBetweenFindEngagePointTests = 1.0;
-const kMaxSleepTimeBetweenFindEngagePointTests = 3.0;
+//const kMinSleepTimeBetweenFindEngagePointTests = 1.0; ->old value
+//const kMaxSleepTimeBetweenFindEngagePointTests = 3.0; ->old value
+const kMinSleepTimeBetweenFindEngagePointTests = 0.2;
+const kMaxSleepTimeBetweenFindEngagePointTests = 0.5;
 
 ///////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
This is ehnancing the decision making while engaging.  Tested with FR.