### PR TITLE
Random SwatOfficer delays before entry

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadMoveAndClearAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadMoveAndClearAction.uc
@@ -461,7 +461,9 @@ latent function OpenTargetDoor(Pawn Officer)
 
 	// only open the door if it's closed and not broken
 	if (CanInteractWithTargetDoor())
-	{
+	{	
+		sleep(FClamp(frand(), 0.0 , 0.3 )); // make AI less perfectly synced 
+
 		ISwatDoor(TargetDoor).RegisterInterestedInDoorOpening(self);
 
 		// have him open the door
@@ -753,6 +755,8 @@ latent function ThrowGrenade()
 	}
 	else
 	{
+		sleep(FClamp(frand(),0.0 , 0.5 ) ); // random wait to make Red and Blue AI less perfectly synced 
+
 		// make sure the throw grenade goal exists
 		assert(CurrentThrowGrenadeGoal != None);
 
@@ -792,7 +796,7 @@ latent function FinishUpThrowBehavior()
 			yield();
 		}
 
-		sleep(PostGrenadeThrowDelayTime);
+		sleep(PostGrenadeThrowDelayTime + FClamp(frand(),0.0 , 0.5 ) ); //random delay added to make Red and Blue AI less perfectly synced
 
 		CurrentThrowGrenadeGoal.unPostGoal(self);
 		CurrentThrowGrenadeGoal.Release();


### PR DESCRIPTION
This makes the Initiate action little bit random so Red and Blue squads are less perfectly synced.  For example if they both throw a bang inside a room the bangs are exploding the exact same time... which is odd... with this they are exploding with little delay ... it feels more natural!